### PR TITLE
Wrapper for dart-sass-embedded executable.

### DIFF
--- a/lib/src/embedded/compiler/process.test.ts
+++ b/lib/src/embedded/compiler/process.test.ts
@@ -1,0 +1,73 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {EmbeddedProcess} from './process';
+import {take} from 'rxjs/operators';
+
+describe('embedded process invocation smoke test', () => {
+  it('spins up child process', () => {
+    const process = new EmbeddedProcess();
+    process.close();
+  });
+
+  it('writes to stdin', () => {
+    const process = new EmbeddedProcess();
+    process.stdin$.next(Buffer.from([0]));
+    process.close();
+  });
+
+  it('writes to stdin repeatedly', () => {
+    const process = new EmbeddedProcess();
+    process.stdin$.next(Buffer.from([0]));
+    process.stdin$.next(Buffer.from([0]));
+    process.stdin$.next(Buffer.from([0]));
+    process.close();
+  });
+
+  it('listens to stdout', async () => {
+    const process = new EmbeddedProcess();
+    const buffer = Buffer.from([
+      20,
+      0,
+      0,
+      0,
+      18,
+      18,
+      8,
+      225,
+      255,
+      148,
+      217,
+      10,
+      18,
+      10,
+      10,
+      8,
+      97,
+      32,
+      123,
+      98,
+      58,
+      32,
+      99,
+      125,
+    ]); // valid message
+    process.stdin$.next(buffer);
+    await process.stdout$.pipe(take(1)).toPromise();
+    process.close();
+  });
+
+  it('listens to stderr', async () => {
+    const process = new EmbeddedProcess();
+    process.stdin$.next(Buffer.from([0, 0, 0, 0, 1])); // invalid message
+    await process.stderr$.pipe(take(1)).toPromise();
+    process.close();
+  });
+
+  it('listens to exit event', async () => {
+    const process = new EmbeddedProcess();
+    process.close();
+    await process.exit$.pipe(take(1)).toPromise();
+  });
+});

--- a/lib/src/embedded/compiler/process.ts
+++ b/lib/src/embedded/compiler/process.ts
@@ -1,0 +1,56 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {spawn} from 'child_process';
+import {resolve} from 'path';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+
+/**
+ * Invokes the Embedded Sass Compiler as a Node child process, exposing its
+ * stdio as Observables.
+ */
+export class EmbeddedProcess {
+  private readonly process = spawn(
+    resolve(__dirname, '../../vendor/dart-sass-embedded'),
+    {
+      windowsHide: true,
+    }
+  );
+
+  private readonly _stdout$ = new Subject<Buffer>();
+
+  private readonly _stderr$ = new Subject<Buffer>();
+
+  private readonly _exit$ = new Subject<number | null>();
+
+  /** Sends the buffers it receives to the child process's stdin. */
+  readonly stdin$ = new Subject<Buffer>();
+
+  /** The buffers emitted by the child process's stdout. */
+  readonly stdout$ = this._stdout$.pipe(takeUntil(this._exit$));
+
+  /** The buffers emitted by the child process's stderr. */
+  readonly stderr$ = this._stderr$.pipe(takeUntil(this._exit$));
+
+  /** The child process's exit event. */
+  readonly exit$ = this._exit$.pipe(takeUntil(this._exit$));
+
+  constructor() {
+    this.stdin$.subscribe(buffer => this.process.stdin.write(buffer));
+    this.process.stdout.on('data', buffer => this._stdout$.next(buffer));
+    this.process.stderr.on('data', buffer => this._stderr$.next(buffer));
+    this.process.on('exit', () => this.close());
+  }
+
+  /**
+   * Kills the child process and cleans up all associated Observables.
+   */
+  close() {
+    this._exit$.next();
+    this._exit$.complete();
+    this.stdin$.complete();
+    this.process.stdin.end();
+  }
+}

--- a/lib/src/embedded/compiler/process.ts
+++ b/lib/src/embedded/compiler/process.ts
@@ -19,28 +19,28 @@ export class EmbeddedProcess {
     }
   );
 
-  private readonly _stdout$ = new Subject<Buffer>();
-
-  private readonly _stderr$ = new Subject<Buffer>();
-
-  private readonly _exit$ = new Subject<number | null>();
+  // These Subjects are written to by the child process's stdio. They are
+  // publicly exposed as readonly Observables to prevent memory leaks.
+  private readonly rawStdout$ = new Subject<Buffer>();
+  private readonly rawStderr$ = new Subject<Buffer>();
+  private readonly rawExit$ = new Subject<number | null>();
 
   /** Sends the buffers it receives to the child process's stdin. */
   readonly stdin$ = new Subject<Buffer>();
 
   /** The buffers emitted by the child process's stdout. */
-  readonly stdout$ = this._stdout$.pipe(takeUntil(this._exit$));
+  readonly stdout$ = this.rawStdout$.pipe(takeUntil(this.rawExit$));
 
   /** The buffers emitted by the child process's stderr. */
-  readonly stderr$ = this._stderr$.pipe(takeUntil(this._exit$));
+  readonly stderr$ = this.rawStderr$.pipe(takeUntil(this.rawExit$));
 
   /** The child process's exit event. */
-  readonly exit$ = this._exit$.pipe(takeUntil(this._exit$));
+  readonly exit$ = this.rawExit$.pipe(takeUntil(this.rawExit$));
 
   constructor() {
     this.stdin$.subscribe(buffer => this.process.stdin.write(buffer));
-    this.process.stdout.on('data', buffer => this._stdout$.next(buffer));
-    this.process.stderr.on('data', buffer => this._stderr$.next(buffer));
+    this.process.stdout.on('data', buffer => this.rawStdout$.next(buffer));
+    this.process.stderr.on('data', buffer => this.rawStderr$.next(buffer));
     this.process.on('exit', () => this.close());
   }
 
@@ -48,8 +48,8 @@ export class EmbeddedProcess {
    * Kills the child process and cleans up all associated Observables.
    */
   close() {
-    this._exit$.next();
-    this._exit$.complete();
+    this.rawExit$.next();
+    this.rawExit$.complete();
     this.stdin$.complete();
     this.process.stdin.end();
   }


### PR DESCRIPTION
Abstracts away invoking the executable.

The tests here are just smoke tests (mostly to ensure this works across Node environments). Compiler behavior will be covered later on by testing the units that send data to the executable, and also through integration tests.