### PR TITLE
Compile function

### DIFF
--- a/lib/src/compile.test.ts
+++ b/lib/src/compile.test.ts
@@ -1,0 +1,229 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {promises as fs} from 'fs';
+import {resolve} from 'path';
+import {fileURLToPath, URL} from 'url';
+
+import {InboundMessage} from './vendor/embedded_sass_pb';
+import {newCompileRequest, newCompileStringRequest, compile} from './compile';
+import {
+  expectEqualPaths,
+  getCompileFailure,
+  getCompileSuccess,
+  getSourceMap,
+  sourceLocation,
+  sourceSpan,
+} from '../../spec/helpers/utils';
+
+describe('compile', () => {
+  it('throws an error upon protocol error', async () => {
+    const request = new InboundMessage.CompileRequest();
+
+    await expectAsync(compile(request)).toBeRejectedWithError(
+      'Compiler reported error: Missing mandatory field CompileRequest.input.'
+    );
+  });
+
+  describe('success', () => {
+    describe('input', () => {
+      it('compiles an SCSS string by default', async () => {
+        const request = newCompileStringRequest({source: 'a {b: c}'});
+        const success = getCompileSuccess(await compile(request));
+
+        expect(success.getCss()).toBe('a {\n  b: c;\n}');
+      });
+
+      // TODO(awjin): compiles an SCSS string explicitly
+      // TODO(awjin): compiles an indented syntax string
+      // TODO(awjin): compiles a plain CSS string
+
+      it('compiles an absolute path', async () => {
+        const path = `${resolve('test.scss')}`;
+        await fs.writeFile(path, 'a {b: c}');
+        const request = newCompileRequest({path});
+        const success = getCompileSuccess(await compile(request));
+
+        expect(success.getCss()).toBe('a {\n  b: c;\n}');
+        await fs.unlink(path);
+      });
+
+      it('compiles a relative path', async () => {
+        const path = 'test.scss';
+        await fs.writeFile(path, 'a {b: c}');
+        const request = newCompileRequest({path});
+        const success = getCompileSuccess(await compile(request));
+
+        expect(success.getCss()).toBe('a {\n  b: c;\n}');
+        await fs.unlink(path);
+      });
+    });
+
+    describe('output', () => {
+      it('outputs in expanded mode by default', async () => {
+        const request = newCompileStringRequest({source: 'a {b: c}'});
+        const success = getCompileSuccess(await compile(request));
+
+        expect(success.getCss()).toBe('a {\n  b: c;\n}');
+      });
+
+      // TODO(awjin): outputs in expanded mode explicitly
+      // TODO(awjin): outputs in compressed mode
+      // TODO(awjin): outputs in expanded mode when nested mode is passed
+      // TODO(awjin): outputs in expanded mode when compact mode is passed
+    });
+
+    describe('sourcemap', () => {
+      it("doesn't include a source map by default", async () => {
+        const request = newCompileStringRequest({source: 'a {b: c}'});
+        const success = getCompileSuccess(await compile(request));
+
+        expect(success.getSourceMap()).toBe('');
+      });
+
+      it("doesn't include a source map explicitly", async () => {
+        const request = newCompileStringRequest({
+          source: 'a {b: c}',
+          sourceMap: false,
+        });
+        const success = getCompileSuccess(await compile(request));
+
+        expect(success.getSourceMap()).toBe('');
+      });
+
+      it('includes a source map', async () => {
+        const request = newCompileStringRequest({
+          source: 'a {b: c}',
+          sourceMap: true,
+        });
+        const sourceMap = await getSourceMap(await compile(request));
+        const originalPosition = sourceMap.originalPositionFor({
+          line: 2,
+          column: 2,
+        });
+
+        expect(originalPosition.line).toBe(1);
+        expect(originalPosition.column).toBe(3);
+      });
+    });
+  });
+
+  describe('failure', () => {
+    describe('input', () => {
+      it('fails on invalid syntax', async () => {
+        const request = newCompileStringRequest({source: 'a {'});
+        const failure = getCompileFailure(await compile(request));
+
+        expect(failure.getMessage()).toBe('expected "}".');
+        expect(failure.getSpan()).toEqual(
+          sourceSpan({
+            text: '',
+            start: sourceLocation(3, 0, 3),
+            end: sourceLocation(3, 0, 3),
+            url: '',
+            context: 'a {',
+          })
+        );
+        expect(failure.getStackTrace()).toBe('- 1:4  root stylesheet\n');
+      });
+
+      it('fails on runtime error', async () => {
+        const request = newCompileStringRequest({source: 'a {b: 1px + 1em}'});
+        const failure = getCompileFailure(await compile(request));
+
+        expect(failure.getMessage()).toBe('Incompatible units em and px.');
+        expect(failure.getSpan()).toEqual(
+          sourceSpan({
+            text: '1px + 1em',
+            start: sourceLocation(6, 0, 6),
+            end: sourceLocation(15, 0, 15),
+            url: '',
+            context: 'a {b: 1px + 1em}',
+          })
+        );
+        expect(failure.getStackTrace()).toBe('- 1:7  root stylesheet\n');
+      });
+
+      it('fails on missing file', async () => {
+        const request = newCompileRequest({path: 'test.scss'});
+        const failure = getCompileFailure(await compile(request));
+
+        const message = failure.getMessage().split(': ');
+        expect(message[0]).toBe('Cannot open file');
+        expectEqualPaths(message[1], `${resolve('test.scss')}`);
+        expect(failure.getStackTrace()).toBe('');
+      });
+
+      // TODO(awjin): fails on Sass features in CSS
+    });
+
+    describe('output', () => {
+      it('emits multi-line source span', async () => {
+        const source = `a {
+  b: 1px +
+     1em;
+}`;
+        const request = newCompileStringRequest({source});
+        const failure = getCompileFailure(await compile(request));
+
+        expect(failure.getMessage()).toBe('Incompatible units em and px.');
+        expect(failure.getSpan()).toEqual(
+          sourceSpan({
+            text: '1px +\n     1em',
+            start: sourceLocation(9, 1, 5),
+            end: sourceLocation(23, 2, 8),
+            url: '',
+            context: '  b: 1px +\n     1em;\n',
+          })
+        );
+        expect(failure.getStackTrace()).toBe('- 2:6  root stylesheet\n');
+      });
+
+      it('emits multiple stack trace entries', async () => {
+        const source = `@function fail() {
+  @return 1px + 1em;
+}
+
+a {
+  b: fail();
+}`;
+        const request = newCompileStringRequest({source});
+        const failure = getCompileFailure(await compile(request));
+
+        expect(failure.getStackTrace()).toBe(
+          '- 2:11  fail()\n- 6:6   root stylesheet\n'
+        );
+      });
+
+      it('displays URL of string input', async () => {
+        const request = newCompileStringRequest({
+          source: 'a {b: 1px + 1em}',
+          url: new URL('foo://bar/baz'),
+        });
+        const failure = getCompileFailure(await compile(request));
+
+        expect(failure.getSpan()?.getUrl()).toBe('foo://bar/baz');
+        expect(failure.getStackTrace()).toBe(
+          'foo://bar/baz 1:7  root stylesheet\n'
+        );
+      });
+
+      it('displays URL of path input', async () => {
+        const path = 'test.scss';
+        await fs.writeFile(path, 'a {b: 1px + 1em}');
+        const request = newCompileRequest({path});
+        const failure = getCompileFailure(await compile(request));
+
+        expectEqualPaths(
+          fileURLToPath(failure.getSpan()!.getUrl()),
+          resolve(path)
+        );
+        expect(failure.getStackTrace()).toBe(`${path} 1:7  root stylesheet\n`);
+        await fs.unlink('test.scss');
+      });
+    });
+  });
+
+  // TODO(awjin): logging tests
+});

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -1,0 +1,95 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {URL} from 'url';
+
+import {EmbeddedCompiler} from './embedded/compiler';
+import {Dispatcher} from './embedded/dispatcher';
+import {MessageTransformer} from './embedded/message-transformer';
+import {PacketTransformer} from './embedded/packet-transformer';
+import {InboundMessage, OutboundMessage} from './vendor/embedded_sass_pb';
+
+/**
+ * Creates a request for compiling a file.
+ */
+export function newCompileRequest(options: {
+  path: string;
+  sourceMap?: boolean;
+}): InboundMessage.CompileRequest {
+  // TODO(awjin): Support complete protocol (importers, functions, etc.)
+  const request = new InboundMessage.CompileRequest();
+  request.setPath(options.path);
+  request.setSourceMap(!!options.sourceMap);
+
+  return request;
+}
+
+/**
+ * Creates a request for compiling a string.
+ */
+export function newCompileStringRequest(options: {
+  source: string;
+  sourceMap?: boolean;
+  url?: URL;
+}): InboundMessage.CompileRequest {
+  // TODO(awjin): Support complete protocol (importers, functions, etc.)
+  const input = new InboundMessage.CompileRequest.StringInput();
+  input.setSource(options.source);
+  if (options.url) input.setUrl(options.url.toString());
+
+  const request = new InboundMessage.CompileRequest();
+  request.setString(input);
+  request.setSourceMap(!!options.sourceMap);
+
+  return request;
+}
+
+/**
+ * Spins up a compiler, then sends it a compile request. Returns a promise that
+ * resolves with the compilation result. After resolving, shuts down the
+ * compiler.
+ */
+export function compile(
+  request: InboundMessage.CompileRequest
+): Promise<OutboundMessage.CompileResponse> {
+  // TODO(awjin):
+  // - Accept logger, importers, and functions, then create registries for each.
+  // - Populate request with importer/function IDs.
+  // - Subscribe logger to dispatcher's log events.
+
+  const embeddedCompiler = new EmbeddedCompiler();
+
+  const packetTransformer = new PacketTransformer(
+    embeddedCompiler.stdout$,
+    buffer => embeddedCompiler.writeStdin(buffer)
+  );
+
+  const messageTransformer = new MessageTransformer(
+    packetTransformer.outboundProtobufs$,
+    packet => packetTransformer.writeInboundProtobuf(packet)
+  );
+
+  const dispatcher = new Dispatcher(
+    messageTransformer.outboundMessages$,
+    message => messageTransformer.writeInboundMessage(message),
+    {
+      handleImportRequest: () => {
+        throw Error('Custom importers not yet implemented.');
+      },
+      handleFileImportRequest: () => {
+        throw Error('Custom file importers not yet implemented.');
+      },
+      handleCanonicalizeRequest: () => {
+        throw Error('Canonicalize not yet implemented.');
+      },
+      handleFunctionCallRequest: () => {
+        throw Error('Custom functions not yet implemented.');
+      },
+    }
+  );
+
+  return dispatcher
+    .sendCompileRequest(request)
+    .finally(() => embeddedCompiler.close());
+}

--- a/lib/src/embedded/dispatcher.test.ts
+++ b/lib/src/embedded/dispatcher.test.ts
@@ -8,7 +8,7 @@ import {InboundMessage, OutboundMessage} from '../vendor/embedded_sass_pb';
 import {InboundTypedMessage, OutboundTypedMessage} from './message-transformer';
 import {Dispatcher} from './dispatcher';
 import {PromiseOr} from '../utils';
-import {expectError} from '../../../spec/helpers/utils';
+import {expectObservableToError} from '../../../spec/helpers/utils';
 
 describe('dispatcher', () => {
   let dispatcher: Dispatcher;
@@ -238,7 +238,7 @@ describe('dispatcher', () => {
     });
 
     it('throws if a request ID overlaps with that of an in-flight request', async done => {
-      expectError(
+      expectObservableToError(
         dispatcher.error$,
         'Request ID 0 is already in use by an in-flight request.',
         done
@@ -256,7 +256,7 @@ describe('dispatcher', () => {
     });
 
     it('throws if a response ID does not match any in-flight request IDs', async done => {
-      expectError(
+      expectObservableToError(
         dispatcher.error$,
         'Response ID 1 does not match any pending requests.',
         done

--- a/lib/src/embedded/message-transformer.test.ts
+++ b/lib/src/embedded/message-transformer.test.ts
@@ -4,7 +4,7 @@
 
 import {Subject, Observable} from 'rxjs';
 
-import {expectError} from '../../../spec/helpers/utils';
+import {expectObservableToError} from '../../../spec/helpers/utils';
 import {MessageTransformer, OutboundTypedMessage} from './message-transformer';
 import {
   InboundMessage,
@@ -82,7 +82,7 @@ describe('message transformer', () => {
 
     describe('protocol error', () => {
       it('fails on invalid buffer', async done => {
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           'Compiler caused error: Invalid buffer.',
           done
@@ -92,7 +92,7 @@ describe('message transformer', () => {
       });
 
       it('fails on empty message', async done => {
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           'Compiler caused error: OutboundMessage.message is not set.',
           done
@@ -102,7 +102,7 @@ describe('message transformer', () => {
       });
 
       it('fails on compile response with missing result', async done => {
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           'Compiler caused error: OutboundMessage.CompileResponse.result is not set.',
           done
@@ -115,7 +115,7 @@ describe('message transformer', () => {
       });
 
       it('fails on function call request with missing identifier', async done => {
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           'Compiler caused error: OutboundMessage.FunctionCallRequest.identifier is not set.',
           done
@@ -129,7 +129,7 @@ describe('message transformer', () => {
 
       it('fails if message contains a protocol error', async done => {
         const errorMessage = 'sad';
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           `Compiler reported error: ${errorMessage}.`,
           done

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jasmine-spec-reporter": "^5.0.2",
     "node-fetch": "^2.6.0",
     "protoc": "^1.0.4",
+    "source-map": "^0.6.1",
     "ts-node": "^8.10.2",
     "ts-protoc-gen": "^0.12.0",
     "typescript": "~3.8.0"

--- a/spec/helpers/utils.ts
+++ b/spec/helpers/utils.ts
@@ -3,6 +3,12 @@
 // https://opensource.org/licenses/MIT.
 
 import {Observable} from 'rxjs';
+import {SourceMapConsumer} from 'source-map';
+
+import {
+  OutboundMessage,
+  SourceSpan,
+} from '../../lib/src/vendor/embedded_sass_pb';
 
 /**
  * Subscribes to `observable` and asserts that it errors with the expected
@@ -21,4 +27,89 @@ export function expectObservableToError<T>(
     },
     () => fail('expected error')
   );
+}
+
+/**
+ * Asserts that the `actual` path is equal to the `expected` one, accounting for
+ * OS differences.
+ */
+export function expectEqualPaths(actual: string, expected: string) {
+  if (process.platform === 'win32') {
+    expect(actual).toBe(expected.toLowerCase());
+  } else {
+    expect(actual).toBe(expected);
+  }
+}
+
+/**
+ * Asserts that `response` contains a compilation success and returns the
+ * success.
+ */
+export function getCompileSuccess(
+  response: OutboundMessage.CompileResponse
+): OutboundMessage.CompileResponse.CompileSuccess {
+  const success = response.getSuccess();
+  expect(success).not.toBe(undefined);
+  return success!;
+}
+
+/**
+ * Asserts that `response` contains a compilation failure and returns the
+ * failure.
+ */
+export function getCompileFailure(
+  response: OutboundMessage.CompileResponse
+): OutboundMessage.CompileResponse.CompileFailure {
+  const failure = response.getFailure();
+  expect(failure).not.toBe(undefined);
+  return failure!;
+}
+
+/**
+ * Asserts that `response` contains a sourceMap. Parses and consumes the
+ * sourceMap, then returns the resulting SourceMapConsumer.
+ */
+export async function getSourceMap(
+  response: OutboundMessage.CompileResponse
+): Promise<SourceMapConsumer> {
+  const success = getCompileSuccess(response);
+  const rawSourceMap = success.getSourceMap();
+  expect(rawSourceMap).not.toBe('');
+  const sourceMap = await new SourceMapConsumer(JSON.parse(rawSourceMap));
+  sourceMap.computeColumnSpans();
+  return sourceMap;
+}
+
+/**
+ * Returns a SourceSpan populated with the given `params`.
+ */
+export function sourceSpan(params: {
+  text: string;
+  start: SourceSpan.SourceLocation;
+  end: SourceSpan.SourceLocation;
+  url: string;
+  context: string;
+}): SourceSpan {
+  const span = new SourceSpan();
+  span.setText(params.text);
+  span.setStart(params.start);
+  span.setEnd(params.end);
+  span.setUrl(params.url);
+  span.setContext(params.context);
+  return span;
+}
+
+/**
+ * Returns a SourceLocation with the given `offset`, `line`, and `column`.
+ */
+export function sourceLocation(
+  offset: number,
+  line: number,
+  column: number
+): SourceSpan.SourceLocation {
+  const location = new SourceSpan.SourceLocation();
+  location.setOffset(offset);
+  location.setLine(line);
+  location.setColumn(column);
+  return location;
 }

--- a/spec/helpers/utils.ts
+++ b/spec/helpers/utils.ts
@@ -5,14 +5,14 @@
 import {Observable} from 'rxjs';
 
 /**
- * Subscribes to `observable` and ensures that it errors with the expected
+ * Subscribes to `observable` and asserts that it errors with the expected
  * `errorMessage`. Calls `done()` to complete the spec.
  */
-export function expectError<T>(
+export function expectObservableToError<T>(
   observable: Observable<T>,
   errorMessage: string,
   done: () => void
-) {
+): void {
   observable.subscribe(
     () => fail('expected error'),
     error => {


### PR DESCRIPTION
Adds a `compile` function that will back the `render` API (and eventually `renderSync` as well as the new JS API methods).

See https://github.com/sass/embedded-host-node/issues/13