### PR TITLE
Compile

### DIFF
--- a/lib/src/compile.test.ts
+++ b/lib/src/compile.test.ts
@@ -1,0 +1,213 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {promises as fs} from 'fs';
+import {resolve} from 'path';
+import {fileURLToPath, URL} from 'url';
+
+import {compile, compileString} from './compile';
+import {expectEqualPaths} from '../../spec/helpers/utils';
+import {RawSourceMap, SourceMapConsumer} from 'source-map';
+
+describe('compile', () => {
+  describe('success', () => {
+    describe('input', () => {
+      it('compiles an SCSS string by default', async () => {
+        expect(await compileString({source: 'a {b: c}'})).toBe(
+          'a {\n  b: c;\n}'
+        );
+      });
+
+      // TODO(awjin): compiles an SCSS string explicitly
+      // TODO(awjin): compiles an indented syntax string
+      // TODO(awjin): compiles a plain CSS string
+
+      it('compiles an absolute path', async () => {
+        const path = `${resolve('test.scss')}`;
+        await fs.writeFile(path, 'a {b: c}');
+
+        expect(await compile({path})).toBe('a {\n  b: c;\n}');
+        await fs.unlink(path);
+      });
+
+      it('compiles a relative path', async () => {
+        const path = 'test.scss';
+        await fs.writeFile(path, 'a {b: c}');
+
+        expect(await compile({path})).toBe('a {\n  b: c;\n}');
+        await fs.unlink(path);
+      });
+    });
+
+    describe('output', () => {
+      it('outputs in expanded mode by default', async () => {
+        expect(await compileString({source: 'a {b: c}'})).toBe(
+          'a {\n  b: c;\n}'
+        );
+      });
+
+      // TODO(awjin): outputs in expanded mode explicitly
+      // TODO(awjin): outputs in compressed mode
+      // TODO(awjin): outputs in expanded mode when nested mode is passed
+      // TODO(awjin): outputs in expanded mode when compact mode is passed
+    });
+
+    describe('sourcemap', () => {
+      it('includes a source map', async () => {
+        let rawSourceMap: RawSourceMap;
+        await compileString({
+          source: 'a {b: c}',
+          sourceMap: map => (rawSourceMap = map),
+        });
+        const sourceMap = await new SourceMapConsumer(rawSourceMap!);
+        sourceMap.computeColumnSpans();
+        const originalPosition = sourceMap.originalPositionFor({
+          line: 2,
+          column: 2,
+        });
+
+        expect(originalPosition.line).toBe(1);
+        expect(originalPosition.column).toBe(3);
+      });
+    });
+  });
+
+  describe('failure', () => {
+    describe('input', () => {
+      it('fails on invalid syntax', async () => {
+        try {
+          await compileString({source: 'a {'});
+        } catch (error) {
+          expect(error.message).toBe('expected "}".');
+          expect(error.span).toEqual({
+            text: '',
+            start: {
+              offset: 3,
+              line: 0,
+              column: 3,
+            },
+            end: {
+              offset: 3,
+              line: 0,
+              column: 3,
+            },
+            url: undefined,
+            context: 'a {',
+          });
+          expect(error.stack).toBe('- 1:4  root stylesheet\n');
+        }
+      });
+
+      it('fails on runtime error', async () => {
+        try {
+          await compileString({source: 'a {b: 1px + 1em}'});
+        } catch (error) {
+          expect(error.message).toBe('Incompatible units em and px.');
+          expect(error.span).toEqual({
+            text: '1px + 1em',
+            start: {
+              offset: 6,
+              line: 0,
+              column: 6,
+            },
+            end: {
+              offset: 15,
+              line: 0,
+              column: 15,
+            },
+            url: undefined,
+            context: 'a {b: 1px + 1em}',
+          });
+          expect(error.stack).toBe('- 1:7  root stylesheet\n');
+        }
+      });
+
+      it('fails on missing file', async () => {
+        try {
+          await compile({path: 'test.scss'});
+        } catch (error) {
+          const message = error.message.split(': ');
+          expect(message[0]).toBe('Cannot open file');
+          expectEqualPaths(message[1], `${resolve('test.scss')}`);
+        }
+      });
+
+      // TODO(awjin): fails on Sass features in CSS
+    });
+
+    describe('output', () => {
+      it('emits multi-line source span', async () => {
+        const source = `a {
+  b: 1px +
+     1em;
+}`;
+        try {
+          await compileString({source});
+        } catch (error) {
+          expect(error.message).toBe('Incompatible units em and px.');
+          expect(error.span).toEqual({
+            text: '1px +\n     1em',
+            start: {
+              offset: 9,
+              line: 1,
+              column: 5,
+            },
+            end: {
+              offset: 23,
+              line: 2,
+              column: 8,
+            },
+            url: undefined,
+            context: '  b: 1px +\n     1em;\n',
+          });
+          expect(error.stack).toBe('- 2:6  root stylesheet\n');
+        }
+      });
+
+      it('emits multiple stack trace entries', async () => {
+        const source = `@function fail() {
+  @return 1px + 1em;
+}
+
+a {
+  b: fail();
+}`;
+        try {
+          await compileString({source});
+        } catch (error) {
+          expect(error.stack).toBe('- 2:11  fail()\n- 6:6   root stylesheet\n');
+        }
+      });
+
+      it('displays URL of string input', async () => {
+        try {
+          await compileString({
+            source: 'a {b: 1px + 1em}',
+            url: new URL('foo://bar/baz'),
+          });
+        } catch (error) {
+          expect(error.span.url).toEqual(new URL('foo://bar/baz'));
+          expect(error.stack).toBe('foo://bar/baz 1:7  root stylesheet\n');
+        }
+      });
+
+      it('displays URL of path input', async () => {
+        const path = 'test.scss';
+        await fs.writeFile(path, 'a {b: 1px + 1em}');
+        try {
+          await compile({
+            path,
+          });
+        } catch (error) {
+          expectEqualPaths(fileURLToPath(error.span.url), resolve(path));
+          expect(error.stack).toBe(`${path} 1:7  root stylesheet\n`);
+        } finally {
+          await fs.unlink(path);
+        }
+      });
+    });
+  });
+
+  // TODO(awjin): logging tests
+});

--- a/lib/src/compile.test.ts
+++ b/lib/src/compile.test.ts
@@ -24,7 +24,7 @@ describe('compile', () => {
       // TODO(awjin): compiles a plain CSS string
 
       it('compiles an absolute path', async () => {
-        const path = `${resolve('test.scss')}`;
+        const path = resolve('test.scss');
         await fs.writeFile(path, 'a {b: c}');
 
         expect(await compile({path})).toBe('a {\n  b: c;\n}');
@@ -130,6 +130,7 @@ describe('compile', () => {
           const message = error.message.split(': ');
           expect(message[0]).toBe('Cannot open file');
           expectEqualPaths(message[1], `${resolve('test.scss')}`);
+          expect(error.span).toBe(undefined);
         }
       });
 

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -100,40 +100,44 @@ async function compileRequest(
   css: string;
   sourceMap?: RawSourceMap;
 }> {
-  // TODO(awjin):
-  // - Subscribe logger to dispatcher's log events.
-  // - Pass import and function registries' handler functions to dispatcher.
-
   const embeddedCompiler = new EmbeddedCompiler();
-  const packetTransformer = new PacketTransformer(
-    embeddedCompiler.stdout$,
-    buffer => embeddedCompiler.writeStdin(buffer)
-  );
-  const messageTransformer = new MessageTransformer(
-    packetTransformer.outboundProtobufs$,
-    packet => packetTransformer.writeInboundProtobuf(packet)
-  );
-  const dispatcher = new Dispatcher(
-    messageTransformer.outboundMessages$,
-    message => messageTransformer.writeInboundMessage(message),
-    {
-      handleImportRequest: () => {
-        throw Error('Custom importers not yet implemented.');
-      },
-      handleFileImportRequest: () => {
-        throw Error('Custom file importers not yet implemented.');
-      },
-      handleCanonicalizeRequest: () => {
-        throw Error('Canonicalize not yet implemented.');
-      },
-      handleFunctionCallRequest: () => {
-        throw Error('Custom functions not yet implemented.');
-      },
-    }
-  );
 
   try {
+    const packetTransformer = new PacketTransformer(
+      embeddedCompiler.stdout$,
+      buffer => embeddedCompiler.writeStdin(buffer)
+    );
+
+    const messageTransformer = new MessageTransformer(
+      packetTransformer.outboundProtobufs$,
+      packet => packetTransformer.writeInboundProtobuf(packet)
+    );
+
+    // TODO(awjin): Pass import and function registries' handler functions to
+    // dispatcher.
+    const dispatcher = new Dispatcher(
+      messageTransformer.outboundMessages$,
+      message => messageTransformer.writeInboundMessage(message),
+      {
+        handleImportRequest: () => {
+          throw Error('Custom importers not yet implemented.');
+        },
+        handleFileImportRequest: () => {
+          throw Error('Custom file importers not yet implemented.');
+        },
+        handleCanonicalizeRequest: () => {
+          throw Error('Canonicalize not yet implemented.');
+        },
+        handleFunctionCallRequest: () => {
+          throw Error('Custom functions not yet implemented.');
+        },
+      }
+    );
+
+    // TODO(awjin): Subscribe logger to dispatcher's log events.
+
     const response = await dispatcher.sendCompileRequest(request);
+
     if (response.getSuccess()) {
       const success = response.getSuccess()!;
       const sourceMap = success.getSourceMap();

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -1,0 +1,163 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {RawSourceMap} from 'source-map';
+import {URL} from 'url';
+
+import {EmbeddedCompiler} from './embedded/compiler';
+import {Dispatcher} from './embedded/dispatcher';
+import {MessageTransformer} from './embedded/message-transformer';
+import {PacketTransformer} from './embedded/packet-transformer';
+import {SassException} from './exception/exception';
+import {deprotifySourceSpan} from './utils';
+import {InboundMessage} from './vendor/embedded_sass_pb';
+
+/**
+ * Compiles a path and returns the resulting css. Throws a SassException if the
+ * compilation failed.
+ */
+export async function compile(options: {
+  path: string;
+  sourceMap?: (sourceMap: RawSourceMap) => void;
+}): Promise<string> {
+  // TODO(awjin): Create logger, importer, function registries.
+
+  const request = newCompileRequest({
+    path: options.path,
+    sourceMap: !!options.sourceMap,
+  });
+
+  const response = await compileRequest(request);
+  if (options.sourceMap && response.sourceMap) {
+    options.sourceMap(response.sourceMap);
+  }
+  return response.css;
+}
+
+/**
+ * Compiles a string and returns the resulting css. Throws a SassException if
+ * the compilation failed.
+ */
+export async function compileString(options: {
+  source: string;
+  sourceMap?: (sourceMap: RawSourceMap) => void;
+  url?: URL;
+}): Promise<string> {
+  // TODO(awjin): Create logger, importer, function registries.
+
+  const request = newCompileStringRequest({
+    source: options.source,
+    sourceMap: !!options.sourceMap,
+    url: options.url,
+  });
+
+  const response = await compileRequest(request);
+  if (options.sourceMap && response.sourceMap) {
+    options.sourceMap(response.sourceMap);
+  }
+  return response.css;
+}
+
+// Creates a request for compiling a file.
+function newCompileRequest(options: {
+  path: string;
+  sourceMap: boolean;
+}): InboundMessage.CompileRequest {
+  // TODO(awjin): Populate request with importer/function IDs.
+
+  const request = new InboundMessage.CompileRequest();
+  request.setPath(options.path);
+  request.setSourceMap(options.sourceMap);
+
+  return request;
+}
+
+// Creates a request for compiling a string.
+function newCompileStringRequest(options: {
+  source: string;
+  sourceMap: boolean;
+  url?: URL;
+}): InboundMessage.CompileRequest {
+  // TODO(awjin): Populate request with importer/function IDs.
+
+  const input = new InboundMessage.CompileRequest.StringInput();
+  input.setSource(options.source);
+  if (options.url) input.setUrl(options.url.toString());
+
+  const request = new InboundMessage.CompileRequest();
+  request.setString(input);
+  request.setSourceMap(options.sourceMap);
+
+  return request;
+}
+
+// Spins up a compiler, then sends it a compile request. Returns a promise that
+// resolves with the CompileResult. Throws a SassException if there were any
+// protocol or compilation errors. Shuts down the compiler after compilation.
+async function compileRequest(
+  request: InboundMessage.CompileRequest
+): Promise<{
+  css: string;
+  sourceMap?: RawSourceMap;
+}> {
+  // TODO(awjin):
+  // - Subscribe logger to dispatcher's log events.
+  // - Pass import and function registries' handler functions to dispatcher.
+
+  const embeddedCompiler = new EmbeddedCompiler();
+  const packetTransformer = new PacketTransformer(
+    embeddedCompiler.stdout$,
+    buffer => embeddedCompiler.writeStdin(buffer)
+  );
+  const messageTransformer = new MessageTransformer(
+    packetTransformer.outboundProtobufs$,
+    packet => packetTransformer.writeInboundProtobuf(packet)
+  );
+
+  const dispatcher = new Dispatcher(
+    messageTransformer.outboundMessages$,
+    message => messageTransformer.writeInboundMessage(message),
+    {
+      handleImportRequest: () => {
+        throw Error('Custom importers not yet implemented.');
+      },
+      handleFileImportRequest: () => {
+        throw Error('Custom file importers not yet implemented.');
+      },
+      handleCanonicalizeRequest: () => {
+        throw Error('Canonicalize not yet implemented.');
+      },
+      handleFunctionCallRequest: () => {
+        throw Error('Custom functions not yet implemented.');
+      },
+    }
+  );
+
+  try {
+    const response = await dispatcher.sendCompileRequest(request);
+
+    if (response.getSuccess()) {
+      const success = response.getSuccess()!;
+      const sourceMap = success.getSourceMap();
+      return {
+        css: success.getCss(),
+        sourceMap: sourceMap ? JSON.parse(sourceMap) : undefined,
+      };
+    } else if (response.getFailure()) {
+      const failure = response.getFailure()!;
+      const span = failure.getSpan();
+      throw new SassException({
+        message: failure.getMessage(),
+        span: span ? deprotifySourceSpan(span) : undefined,
+        stack: failure.getStackTrace(),
+      });
+    } else {
+      throw new SassException({
+        message: 'Compiler sent empty CompileResponse.',
+      });
+    }
+  } finally {
+    embeddedCompiler.close();
+  }
+}

--- a/lib/src/embedded/dispatcher.test.ts
+++ b/lib/src/embedded/dispatcher.test.ts
@@ -8,7 +8,7 @@ import {InboundMessage, OutboundMessage} from '../vendor/embedded_sass_pb';
 import {InboundTypedMessage, OutboundTypedMessage} from './message-transformer';
 import {Dispatcher} from './dispatcher';
 import {PromiseOr} from '../utils';
-import {expectError} from '../../../spec/helpers/utils';
+import {expectObservableToError} from '../../../spec/helpers/utils';
 
 describe('dispatcher', () => {
   let dispatcher: Dispatcher;
@@ -238,7 +238,7 @@ describe('dispatcher', () => {
     });
 
     it('throws if a request ID overlaps with that of an in-flight request', async done => {
-      expectError(
+      expectObservableToError(
         dispatcher.error$,
         'Request ID 0 is already in use by an in-flight request.',
         done
@@ -256,7 +256,7 @@ describe('dispatcher', () => {
     });
 
     it('throws if a response ID does not match any in-flight request IDs', async done => {
-      expectError(
+      expectObservableToError(
         dispatcher.error$,
         'Response ID 1 does not match any pending requests.',
         done

--- a/lib/src/embedded/dispatcher.test.ts
+++ b/lib/src/embedded/dispatcher.test.ts
@@ -106,6 +106,15 @@ describe('dispatcher', () => {
           done();
         });
     });
+
+    it('errors if dispatcher is already closed', async () => {
+      dispatcher = createDispatcher(outbound$, () => {});
+      outbound$.complete();
+
+      await expectAsync(
+        dispatcher.sendCompileRequest(new InboundMessage.CompileRequest())
+      ).toBeRejectedWithError('Tried writing to closed dispatcher');
+    });
   });
 
   describe('outbound requests', () => {
@@ -272,7 +281,7 @@ describe('dispatcher', () => {
 
     it('throws error to compile request senders', async () => {
       const error = 'fail';
-      outbound$.error(error);
+      dispatcher = createDispatcher(outbound$, () => outbound$.error(error));
 
       await expectAsync(
         dispatcher.sendCompileRequest(new InboundMessage.CompileRequest())

--- a/lib/src/embedded/dispatcher.ts
+++ b/lib/src/embedded/dispatcher.ts
@@ -211,6 +211,10 @@ export class Dispatcher {
     responseType: OutboundResponseType
   ): Promise<OutboundResponse> {
     return new Promise((resolve, reject) => {
+      if (this.messages$.isStopped) {
+        reject(Error('Tried writing to closed dispatcher'));
+      }
+
       this.messages$
         .pipe(
           filter(message => message.type === responseType),

--- a/lib/src/embedded/message-transformer.test.ts
+++ b/lib/src/embedded/message-transformer.test.ts
@@ -4,7 +4,7 @@
 
 import {Subject, Observable} from 'rxjs';
 
-import {expectError} from '../../../spec/helpers/utils';
+import {expectObservableToError} from '../../../spec/helpers/utils';
 import {MessageTransformer, OutboundTypedMessage} from './message-transformer';
 import {
   InboundMessage,
@@ -82,7 +82,7 @@ describe('message transformer', () => {
 
     describe('protocol error', () => {
       it('fails on invalid buffer', async done => {
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           'Compiler caused error: Invalid buffer.',
           done
@@ -92,7 +92,7 @@ describe('message transformer', () => {
       });
 
       it('fails on empty message', async done => {
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           'Compiler caused error: OutboundMessage.message is not set.',
           done
@@ -102,7 +102,7 @@ describe('message transformer', () => {
       });
 
       it('fails on compile response with missing result', async done => {
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           'Compiler caused error: OutboundMessage.CompileResponse.result is not set.',
           done
@@ -115,7 +115,7 @@ describe('message transformer', () => {
       });
 
       it('fails on function call request with missing identifier', async done => {
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           'Compiler caused error: OutboundMessage.FunctionCallRequest.identifier is not set.',
           done
@@ -129,7 +129,7 @@ describe('message transformer', () => {
 
       it('fails if message contains a protocol error', async done => {
         const errorMessage = 'sad';
-        expectError(
+        expectObservableToError(
           messages.outboundMessages$,
           `Compiler reported error: ${errorMessage}.`,
           done

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jasmine-spec-reporter": "^5.0.2",
     "node-fetch": "^2.6.0",
     "protoc": "^1.0.4",
+    "source-map": "^0.6.1",
     "ts-node": "^8.10.2",
     "ts-protoc-gen": "^0.12.0",
     "typescript": "~3.8.0"

--- a/spec/helpers/utils.ts
+++ b/spec/helpers/utils.ts
@@ -22,3 +22,15 @@ export function expectObservableToError<T>(
     () => fail('expected error')
   );
 }
+
+/**
+ * Asserts that the `actual` path is equal to the `expected` one, accounting for
+ * OS differences.
+ */
+export function expectEqualPaths(actual: string, expected: string): void {
+  if (process.platform === 'win32') {
+    expect(actual).toBe(expected.toLowerCase());
+  } else {
+    expect(actual).toBe(expected);
+  }
+}

--- a/spec/helpers/utils.ts
+++ b/spec/helpers/utils.ts
@@ -5,14 +5,14 @@
 import {Observable} from 'rxjs';
 
 /**
- * Subscribes to `observable` and ensures that it errors with the expected
+ * Subscribes to `observable` and asserts that it errors with the expected
  * `errorMessage`. Calls `done()` to complete the spec.
  */
-export function expectError<T>(
+export function expectObservableToError<T>(
   observable: Observable<T>,
   errorMessage: string,
   done: () => void
-) {
+): void {
   observable.subscribe(
     () => fail('expected error'),
     error => {


### PR DESCRIPTION
Adds a `compile` function that will back the `render` API (and eventually `renderSync` as well as the new JS API methods).

See https://github.com/sass/embedded-host-node/issues/13