### PR TITLE
Add a postinstall script.

### DIFF
--- a/.dev
+++ b/.dev
@@ -1,0 +1,14 @@
+# Problem
+
+The npm post-install hook provides no way to differentiate a developer who runs
+`npm install` to develop this package from an end-user who runs `npm install` to
+get the package from npm. Only end-users need to download the Embedded Compiler
+binary during post-install.
+
+# Solution
+
+This file only exists in this package's repo. It is excluded from the tarball
+published to npm. During post-install, we first verify that this file does not
+exist before downloading the compiler.
+
+See: `./download-compiler-for-end-user.js`

--- a/download-compiler-for-end-user.js
+++ b/download-compiler-for-end-user.js
@@ -1,0 +1,21 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+const fs = require('fs');
+
+if (fs.existsSync('.dev')) return;
+
+const getDartSassEmbedded = require('./dist/tool/utils.js').getDartSassEmbedded;
+
+(async () => {
+  try {
+    await getDartSassEmbedded({
+      outPath: './dist/lib/src/vendor',
+      release: true,
+    });
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "download-compiler-for-end-user.js"
   ],
   "engines": {
     "node": ">=12.18.2"
@@ -19,6 +20,7 @@
     "clean": "gts clean",
     "compile": "tsc",
     "fix": "gts fix",
+    "postinstall": "node ./download-compiler-for-end-user.js",
     "prepublishOnly": "npm run clean && ts-node ./tool/prepare-release.ts",
     "test": "ts-node ./node_modules/jasmine/bin/jasmine"
   },


### PR DESCRIPTION
This downloads the latest release of the compiler after an end-user `npm install`s
the host.

See https://github.com/sass/embedded-host-node/issues/37