### PR TITLE
Add prepublish script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clean": "gts clean",
     "compile": "tsc",
     "fix": "gts fix",
+    "prepublishOnly": "npm run clean && ts-node ./tool/prepare-release.ts",
     "test": "ts-node ./node_modules/jasmine/bin/jasmine"
   },
   "dependencies": {

--- a/tool/prepare-release.ts
+++ b/tool/prepare-release.ts
@@ -1,0 +1,24 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {promises as fs} from 'fs';
+import * as shell from 'shelljs';
+
+import {getEmbeddedProtocol} from './utils';
+
+shell.config.fatal = true;
+
+(async () => {
+  await getEmbeddedProtocol({outPath: 'lib/src/vendor', release: true});
+
+  console.log('Transpiling TS into dist.');
+  shell.exec('tsc');
+
+  // .gitignore needs to exist in dist for `npm publish` to correctly exclude
+  // files from the published tarball.
+  console.log('Copying .gitignore to dist.');
+  await fs.copyFile('.gitignore', 'dist/.gitignore');
+
+  console.log('Ready for publishing to npm.');
+})();

--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -69,6 +69,7 @@ export async function getEmbeddedProtocol(options: {
   release?: boolean;
 }): Promise<void> {
   const repo = 'embedded-protocol';
+
   if (options.release) {
     const latestRelease = await getLatestReleaseInfo({
       repo,
@@ -81,31 +82,23 @@ export async function getEmbeddedProtocol(options: {
         `https://github.com/sass/${repo}/archive/` +
         `${latestRelease.name.replace(' ', '-')}` +
         ARCHIVE_EXTENSION,
-      outPath: options.outPath,
+      outPath: BUILD_PATH,
     });
     fs.rename(
-      p.join(
-        options.outPath,
-        `${repo}-${latestRelease.name.replace(' ', '-')}`
-      ),
-      p.join(options.outPath, repo)
+      p.join(BUILD_PATH, `${repo}-${latestRelease.name.replace(' ', '-')}`),
+      p.join(BUILD_PATH, repo)
     );
-    buildEmbeddedProtocol(p.join(options.outPath, repo));
-  } else if (options.path) {
-    buildEmbeddedProtocol(p.join(options.path));
-    await linkBuiltFiles(options.path, p.join(options.outPath, repo));
-  } else {
+  } else if (!options.path) {
     fetchRepo({
       repo,
       outPath: BUILD_PATH,
       ref: options.version,
     });
-    buildEmbeddedProtocol(p.join(BUILD_PATH, repo));
-    await linkBuiltFiles(
-      p.join(BUILD_PATH, repo),
-      p.join(options.outPath, repo)
-    );
   }
+
+  const repoPath = options.path ?? p.join(BUILD_PATH, repo);
+  buildEmbeddedProtocol(repoPath);
+  await linkBuiltFiles(repoPath, p.join(options.outPath, repo));
 }
 
 /**


### PR DESCRIPTION
This adds a script that runs during the `prepublishOnly` hook (which occurs right before `npm publish`). The script builds the latest release of the Embedded Protocol, transpiles TS source to JS, then outputs the result of both into the `dist` directory.

See https://github.com/sass/embedded-host-node/issues/37