### PR TITLE
Specify compiler version for end-user download.

### DIFF
--- a/download-compiler-for-end-user.js
+++ b/download-compiler-for-end-user.js
@@ -7,12 +7,14 @@ const fs = require('fs');
 if (fs.existsSync('.dev')) return;
 
 const getDartSassEmbedded = require('./dist/tool/utils.js').getDartSassEmbedded;
+const pkg = require('./package.json');
 
 (async () => {
   try {
     await getDartSassEmbedded({
       outPath: './dist/lib/src/vendor',
       release: true,
+      version: pkg['compiler-version'],
     });
   } catch (error) {
     console.error(error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sass-embedded",
   "version": "1.0.0-alpha.1",
+  "compiler-version": "1.0.0-beta.7",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",

--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -74,7 +74,6 @@ export async function getEmbeddedProtocol(options: {
     const latestRelease = await getLatestReleaseInfo({
       repo,
       tag: true,
-      // TODO(awjin): versionConstraint
     });
     await downloadRelease({
       repo,
@@ -105,7 +104,9 @@ export async function getEmbeddedProtocol(options: {
  * Gets the latest version of the Dart Sass wrapper for the Embedded Compiler.
  * Throws if an error occurs.
  *
- * @param version - The Git ref to check out and build. Defaults to `master`.
+ * @param version - If `release` is true, the version of the released binary to
+ *   download (defaults to the latest version). If it's false, the Git ref to
+ *   check out and build (defaults to master).
  * @param path - Build from this path instead of pulling from Github.
  * @param release - Download the latest release instead of building from source.
  */
@@ -118,16 +119,17 @@ export async function getDartSassEmbedded(options: {
   const repo = 'dart-sass-embedded';
 
   if (options.release) {
-    const latestRelease = await getLatestReleaseInfo({
-      repo,
-      // TODO(awjin): versionConstraint
-    });
+    const release = options.version
+      ? {tag_name: options.version, name: `sass_embedded ${options.version}`}
+      : await getLatestReleaseInfo({
+          repo,
+        });
     await downloadRelease({
       repo,
       assetUrl:
         `https://github.com/sass/${repo}/releases/download/` +
-        `${latestRelease.tag_name}/` +
-        `${latestRelease.name.replace(' ', '-')}-` +
+        `${release.tag_name}/` +
+        `${release.name.replace(' ', '-')}-` +
         `${OS}-${ARCH}` +
         ARCHIVE_EXTENSION,
       outPath: options.outPath,


### PR DESCRIPTION
This specifies the compiler version in `package.json`. Each release of the host will download that specified version to the end-user. In the future, we can continue to manually update the `package.json` entry, or lean on the synchronized version system and have the host download the compiler that matches its own version.