### PR TITLE
Fix download of dart-sass-embedded on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.1
+
+- Downlaod the compiler binary to the correct directory on Windows.
+
 ## 1.0.0-beta.0
 
 - Release Embedded Host beta with limited support for `render()`, which compiles

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-embedded",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "compiler-version": "1.0.0-beta.7",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
   "repository": "sass/embedded-host-node",

--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -222,7 +222,7 @@ async function downloadRelease(options: {
   await fs.writeFile(zippedAssetPath, releaseAsset);
   if (OS === 'windows') {
     await extractZip(zippedAssetPath, {
-      dir: process.cwd(),
+      dir: p.join(process.cwd(), options.outPath),
     });
   } else {
     extractTar({


### PR DESCRIPTION
Running `node ./download-compiler-for-end-user.js` during the build process fails on Windows, see https://github.com/joomla/joomla-cms/pull/33170#issuecomment-821800324 .

This pull request fixes that.