### PR TITLE
Fix data: URI in source map sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-beta.3
+
+- Properly handle `data:` URIs in sourceMap sources.
+
 ## 1.0.0-beta.2
 
 - No user visible changes.

--- a/lib/src/node-sass/render.ts
+++ b/lib/src/node-sass/render.ts
@@ -158,8 +158,10 @@ function newRenderResult(
     }
 
     sourceMap.sources = sourceMap.sources.map(source => {
-      if (source === 'stdin') return source;
-      return p.relative(sourceMapDir, fileURLToPath(source));
+      if (source.startsWith('file://')) {
+        return p.relative(sourceMapDir, fileURLToPath(source));
+      }
+      return source;
     });
 
     sourceMapBytes = Buffer.from(JSON.stringify(sourceMap));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-embedded",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3-dev",
   "compiler-version": "1.0.0-beta.7",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
   "repository": "sass/embedded-host-node",


### PR DESCRIPTION
In some cases, `dart-sass-embedded` returns `data:` URI for `source` in the `sourceMap.sources`, which would break the current code.

This PR fixes it by check if `source.startsWith('file://')` as detection for `file:` uri only.