### PR TITLE
Allow installing on arm64.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.0.0-beta.4
 
+- Allow installing on arm64.
+
 - Function and Values API
   - Add `sassTrue` and `sassFalse` singletons.
   - Add `SassNumber` class.

--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -38,6 +38,11 @@ const ARCH: 'ia32' | 'x64' = (() => {
       return 'ia32';
     case 'x64':
       return 'x64';
+    // TODO: This is blocked until Github Actions supports compiling Dart Sass
+    // for arm64. Until then, download the x64 binary for arm64 users.
+    // https://github.com/sass/dart-sass/issues/1125
+    case 'arm64':
+      return 'x64';
     default:
       throw Error(`Architecure ${process.arch} is not supported.`);
   }


### PR DESCRIPTION
Partially addresses https://github.com/sass/embedded-host-node/issues/66.