### PR TITLE
Implement indentedSyntax option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Function and Values API
   - Add `SassColor` class.
+- Add `indentedSyntax` option to `render()`
 
 ## 1.0.0-beta.4
 

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -10,7 +10,10 @@ import {PacketTransformer} from './embedded-compiler/packet-transformer';
 import {MessageTransformer} from './embedded-protocol/message-transformer';
 import {Dispatcher} from './embedded-protocol/dispatcher';
 import {deprotifyException} from './embedded-protocol/utils';
-import {InboundMessage} from './vendor/embedded-protocol/embedded_sass_pb';
+import {
+  InboundMessage,
+  Syntax,
+} from './vendor/embedded-protocol/embedded_sass_pb';
 
 /**
  * Compiles a path and returns the resulting css. Throws a SassException if the
@@ -42,6 +45,7 @@ export async function compileString(options: {
   source: string;
   sourceMap?: (sourceMap: RawSourceMap) => void;
   url?: URL | string;
+  indentedSyntax?: boolean;
 }): Promise<string> {
   // TODO(awjin): Create logger, importer, function registries.
 
@@ -49,6 +53,7 @@ export async function compileString(options: {
     source: options.source,
     sourceMap: !!options.sourceMap,
     url: options.url instanceof URL ? options.url.toString() : options.url,
+    indentedSyntax: !!options.indentedSyntax,
   });
 
   const response = await compileRequest(request);
@@ -77,11 +82,13 @@ function newCompileStringRequest(options: {
   source: string;
   sourceMap: boolean;
   url?: string;
+  indentedSyntax: boolean;
 }): InboundMessage.CompileRequest {
   // TODO(awjin): Populate request with importer/function IDs.
 
   const input = new InboundMessage.CompileRequest.StringInput();
   input.setSource(options.source);
+  if (options.indentedSyntax) input.setSyntax(Syntax['INDENTED']);
   if (options.url) input.setUrl(options.url.toString());
 
   const request = new InboundMessage.CompileRequest();

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -88,10 +88,13 @@ function newCompileStringRequest(options: {
   const input = new proto.InboundMessage.CompileRequest.StringInput();
   input.setSource(options.source);
 
-  if (options.syntax === 'scss') input.setSyntax(proto.Syntax['SCSS']);
-  else if (options.syntax === 'indented')
+  if (options.syntax === 'scss') {
+    input.setSyntax(proto.Syntax['SCSS']);
+  } else if (options.syntax === 'indented') {
     input.setSyntax(proto.Syntax['INDENTED']);
-  else if (options.syntax === 'css') input.setSyntax(proto.Syntax['CSS']);
+  } else if (options.syntax === 'css') {
+    input.setSyntax(proto.Syntax['CSS']);
+  }
 
   if (options.url) input.setUrl(options.url.toString());
 

--- a/lib/src/node-sass/render.test.ts
+++ b/lib/src/node-sass/render.test.ts
@@ -141,6 +141,19 @@ describe('render', () => {
         });
       });
     });
+
+    it('renders indented syntax if indentedSyntax is enabled', done => {
+      render(
+        {
+          data: 'a\n\tb: c',
+          indentedSyntax: true,
+        },
+        (_, result) => {
+          expectEqualIgnoringWhitespace(result!.css.toString(), 'a {b: c;}');
+          done();
+        }
+      );
+    });
   });
 
   describe('imports', () => {

--- a/lib/src/node-sass/render.test.ts
+++ b/lib/src/node-sass/render.test.ts
@@ -142,7 +142,7 @@ describe('render', () => {
       });
     });
 
-    it('renders indented syntax if indentedSyntax is enabled', done => {
+    it('renders a string with indented syntax', done => {
       render(
         {
           data: 'a\n\tb: c',

--- a/lib/src/node-sass/render.test.ts
+++ b/lib/src/node-sass/render.test.ts
@@ -154,6 +154,16 @@ describe('render', () => {
         }
       );
     });
+
+    it('renders a file with indented syntax', async () => {
+      await sandbox.run(async dir => {
+        await fs.writeFile(dir('test.sass'), 'a\n\tb: c');
+
+        await expectRenderResult({file: dir('test.sass')}, result => {
+          expectEqualIgnoringWhitespace(result.css.toString(), 'a {b: c;}');
+        });
+      });
+    });
   });
 
   describe('imports', () => {

--- a/lib/src/node-sass/render.ts
+++ b/lib/src/node-sass/render.ts
@@ -25,6 +25,7 @@ interface FileOptions extends SharedOptions {
 interface StringOptions extends SharedOptions {
   data: string;
   file?: string;
+  indentedSyntax?: boolean;
 }
 
 interface SharedOptions {
@@ -38,7 +39,6 @@ interface SharedOptions {
   // TODO(awjin): https://github.com/sass/embedded-host-node/issues/13
   // importer
   // includePaths
-  // indentedSyntax
   // functions
   // outputStyle
 }
@@ -108,6 +108,7 @@ export function render(
         source: stringRequest.data,
         sourceMap: getSourceMap,
         url: stringRequest.file ? pathToFileURL(stringRequest.file) : 'stdin',
+        indentedSyntax: stringRequest.indentedSyntax,
       })
     : compile({path: fileRequest.file, sourceMap: getSourceMap});
 

--- a/lib/src/node-sass/render.ts
+++ b/lib/src/node-sass/render.ts
@@ -108,7 +108,7 @@ export function render(
         source: stringRequest.data,
         sourceMap: getSourceMap,
         url: stringRequest.file ? pathToFileURL(stringRequest.file) : 'stdin',
-        indentedSyntax: stringRequest.indentedSyntax,
+        syntax: stringRequest.indentedSyntax ? 'indented' : 'scss',
       })
     : compile({path: fileRequest.file, sourceMap: getSourceMap});
 


### PR DESCRIPTION
As far as I understand it `indentedSyntax` is only applicable when compiling a string, and not when compiling a file.