### PR TITLE
Update dependencies

### DIFF
--- a/lib/src/compile.test.ts
+++ b/lib/src/compile.test.ts
@@ -8,7 +8,7 @@ import {fileURLToPath} from 'url';
 
 import {compile, compileString} from './compile';
 import {expectEqualPaths} from '../../spec/helpers/utils';
-import {RawSourceMap, SourceMapConsumer} from 'source-map';
+import {RawSourceMap, SourceMapConsumer} from 'source-map-js';
 
 describe('compile', () => {
   describe('success', () => {

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -2,7 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import {RawSourceMap} from 'source-map';
+import {RawSourceMap} from 'source-map-js';
 import {URL} from 'url';
 
 import {EmbeddedCompiler} from './embedded-compiler/compiler';

--- a/lib/src/node-sass/render.test.ts
+++ b/lib/src/node-sass/render.test.ts
@@ -4,7 +4,7 @@
 
 import {promises as fs} from 'fs';
 import * as p from 'path';
-import {RawSourceMap} from 'source-map';
+import {RawSourceMap} from 'source-map-js';
 import {pathToFileURL} from 'url';
 
 import * as sandbox from '../../../spec/helpers/sandbox';

--- a/lib/src/node-sass/render.ts
+++ b/lib/src/node-sass/render.ts
@@ -3,7 +3,7 @@
 // https://opensource.org/licenses/MIT.
 
 import * as p from 'path';
-import {RawSourceMap} from 'source-map';
+import {RawSourceMap} from 'source-map-js';
 import {fileURLToPath, pathToFileURL} from 'url';
 
 import {compile, compileString} from '../compile';

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "google-protobuf": "^3.11.4",
     "immutable": "^4.0.0",
     "node-fetch": "^2.6.0",
-    "rxjs": "^6.5.5",
-    "semver": "^5.7.1",
+    "rxjs": "^7.4.0",
+    "semver": "^7.3.5",
     "shelljs": "^0.8.4",
     "tar": "^6.0.5"
   },
@@ -45,17 +45,17 @@
     "@types/node-fetch": "^2.5.7",
     "@types/semver": "^7.3.4",
     "@types/shelljs": "^0.8.8",
-    "@types/tar": "^4.0.3",
-    "@types/yargs": "^15.0.12",
+    "@types/tar": "^6.1.0",
+    "@types/yargs": "^17.0.4",
     "del": "^6.0.0",
     "gts": "^3.1.0",
     "jest": "^27.2.5",
     "protoc": "^1.0.4",
-    "source-map": "^0.6.1",
+    "source-map-js": "^0.6.1",
     "ts-jest": "^27.0.5",
     "ts-node": "^10.2.1",
-    "ts-protoc-gen": "^0.12.0",
+    "ts-protoc-gen": "^0.15.0",
     "typescript": "^4.4.3",
-    "yargs": "^16.2.0"
+    "yargs": "^17.2.1"
   }
 }

--- a/tool/prepare-dev-environment.ts
+++ b/tool/prepare-dev-environment.ts
@@ -35,7 +35,8 @@ const argv = yargs(process.argv.slice(2))
   .conflicts({'compiler-path': ['compiler-ref', 'compiler-version']})
   .conflicts('compiler-ref', 'compiler-version')
   .conflicts({'protocol-path': ['protocol-ref', 'protocol-version']})
-  .conflicts('protocol-ref', 'protocol-version').argv;
+  .conflicts('protocol-ref', 'protocol-version')
+  .parseSync();
 
 (async () => {
   try {


### PR DESCRIPTION
The sole exception is node-fetch, the latest version of which is
ESM-exclusive which doesn't (currently) play well at all with ts-node.