### PR TITLE
Wait for the embedded process to exit before returning

### DIFF
--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -153,5 +153,6 @@ async function compileRequest(request: InboundMessage.CompileRequest): Promise<{
     }
   } finally {
     embeddedCompiler.close();
+    await embeddedCompiler.exit$;
   }
 }

--- a/lib/src/embedded-compiler/compiler.test.ts
+++ b/lib/src/embedded-compiler/compiler.test.ts
@@ -66,7 +66,7 @@ describe('embedded compiler smoke test', () => {
   it('listens to exit event', async () => {
     const compiler = new EmbeddedCompiler();
     compiler.close();
-    const output = await compiler.exit$.pipe(take(1)).toPromise();
+    const output = await compiler.exit$;
 
     expect(output).not.toBeNull();
   });

--- a/lib/src/embedded-compiler/compiler.ts
+++ b/lib/src/embedded-compiler/compiler.ts
@@ -34,8 +34,8 @@ export class EmbeddedCompiler {
   })();
 
   /** The child process's exit event. */
-  readonly exit$ = new Observable<number | null>(observer => {
-    this.process.on('exit', code => observer.next(code));
+  readonly exit$ = new Promise<number | null>(resolve => {
+    this.process.on('exit', code => resolve(code));
   });
 
   /** The buffers emitted by the child process's stdout. */


### PR DESCRIPTION
This adds some amount of overhead, but hopefully we can mitigate that once
we provide users with the ability to keep a compiler process open across
multiple compile invocations. In exchange, this helps avoid issues like
jest complaining that it hasn't exited in the expected amount of time due
to dangling handle.