### PR TITLE
Use clone-linked-repo to check out the embedded protocol/compiler

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 build/
 dist/
+language/
 lib/src/vendor/
 **/*.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 build/
 dist/
 language/
+embedded-protocol/
 lib/src/vendor/
 **/*.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - run: npm install
       - name: npm run init
         run: |
-          npm run init \
+          npm run init -- \
             --protocol-path=embedded-protocol \
             --compiler-path=dart-sass-embedded \
             --api-path=language
@@ -113,7 +113,7 @@ jobs:
       - run: npm install
       - name: npm run init
         run: |
-          npm run init \
+          npm run init -- \
             --protocol-path=embedded-protocol \
             --compiler-path=dart-sass-embedded \
             --api-path=language
@@ -175,7 +175,7 @@ jobs:
       - run: npm install
       - name: npm run init
         run: |
-          npm run init \
+          npm run init -- \
             --protocol-path=embedded-protocol \
             --compiler-path=dart-sass-embedded \
             --api-path=language

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,38 @@ jobs:
           repo-token: '${{ github.token }}'
       - uses: dart-lang/setup-dart@v1
         with: {sdk: stable}
+      - run: dart --version
+
+      - name: Read package.json
+        id: pkg
+        run: |
+          echo ::set-output "name=protocol-version::$(jq -r '.["protocol-version"]' package.json)"
+          echo ::set-output "name=compiler-version::$(jq -r '.["compiler-version"]' package.json)"
+
+      - name: Check out the embedded protocol
+        uses: sass/clone-linked-repo@v1
+        with:
+          repo: sass/embedded-protocol
+          default-ref: ${{ steps.pkg.outputs.protocol-version }}
+
+      - name: Check out the embedded compiler
+        uses: sass/clone-linked-repo@v1
+        with:
+          repo: sass/dart-sass-embedded
+          default-ref: ${{ steps.pkg.outputs.compiler-version }}
+
+      - name: Check out the JS API definition
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/sass, path: language}
+
       - run: npm install
-      - run: npm run init
+      - name: npm run init
+        run: |
+          npm run init \
+            --protocol-path=embedded-protocol \
+            --compiler-path=dart-sass-embedded \
+            --api-path=language
+
       - run: npm run check
 
   tests:
@@ -57,8 +87,37 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with: {sdk: stable}
       - run: dart --version
+
+      - name: Read package.json
+        id: pkg
+        run: |
+          echo ::set-output "name=protocol-version::$(jq -r '.["protocol-version"]' package.json)"
+          echo ::set-output "name=compiler-version::$(jq -r '.["compiler-version"]' package.json)"
+
+      - name: Check out the embedded protocol
+        uses: sass/clone-linked-repo@v1
+        with:
+          repo: sass/embedded-protocol
+          default-ref: ${{ steps.pkg.outputs.protocol-version }}
+
+      - name: Check out the embedded compiler
+        uses: sass/clone-linked-repo@v1
+        with:
+          repo: sass/dart-sass-embedded
+          default-ref: ${{ steps.pkg.outputs.compiler-version }}
+
+      - name: Check out the JS API definition
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/sass, path: language}
+
       - run: npm install
-      - run: npm run init
+      - name: npm run init
+        run: |
+          npm run init \
+            --protocol-path=embedded-protocol \
+            --compiler-path=dart-sass-embedded \
+            --api-path=language
+
       - run: npm run test
 
   # The versions should be kept up-to-date with the latest LTS Node releases.
@@ -90,7 +149,36 @@ jobs:
         with:
           version: ${{ env.PROTOC_VERSION }}
           repo-token: '${{ github.token }}'
+
+      - name: Read package.json
+        id: pkg
+        run: |
+          echo ::set-output "name=protocol-version::$(jq -r '.["protocol-version"]' package.json)"
+          echo ::set-output "name=compiler-version::$(jq -r '.["compiler-version"]' package.json)"
+
+      - name: Check out the embedded protocol
+        uses: sass/clone-linked-repo@v1
+        with:
+          repo: sass/embedded-protocol
+          default-ref: ${{ steps.pkg.outputs.protocol-version }}
+
+      - name: Check out the embedded compiler
+        uses: sass/clone-linked-repo@v1
+        with:
+          repo: sass/dart-sass-embedded
+          default-ref: ${{ steps.pkg.outputs.compiler-version }}
+
+      - name: Check out the JS API definition
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/sass, path: language}
+
       - run: npm install
+      - name: npm run init
+        run: |
+          npm run init \
+            --protocol-path=embedded-protocol \
+            --compiler-path=dart-sass-embedded \
+            --api-path=language
 
       - name: Check out sass-spec
         uses: sass/clone-linked-repo@v1
@@ -102,17 +190,8 @@ jobs:
 
       - name: Compile
         run: |
-          npm run init
           npm run compile
           ln -s {`pwd`/,dist/}lib/src/vendor/dart-sass-embedded
-          # Prefer the Sass specification to the natively-generated .d.ts files.
-          # This ensures that features the embedded host doesn't yet support
-          # don't cause compile-time failures.
-          find dist -name '*.d.ts' -exec rm {} \;
-
-      - name: Check out Sass specification
-        uses: sass/clone-linked-repo@v1
-        with: {repo: sass/sass, path: language}
 
       - name: Run tests
         run: npm run js-api-spec -- --sassPackage .. --sassSassRepo ../language


### PR DESCRIPTION
This defaults to checking out the versions listed in the pubspec, but
can be overridden for an individual pull request. Note that since the
main branch still always runs tests against specific released
versions, this requires that linked PRs be rolled into tagged releases
immediately after being landed.

The alternative would be to always run local tests against the main
branches of the protocol/compiler repos, but that means we may be
testing against a different version than we release against which
would be quite bad.