### PR TITLE
Allow dependencies on dev branches of the embedded protocol/compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,12 @@ jobs:
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
+
+      - name: "Check we're not using a -dev version of the embedded protocol"
+        run: jq -r '.["protocol-version"]' package.json | grep -qv -- '-dev$'
+      - name: "Check we're not using a -dev version of the embedded compiler"
+        run: jq -r '.["compiler-version"]' package.json | grep -qv -- '-dev$'
+
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'

--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -78,8 +78,9 @@ export async function getEmbeddedProtocol(
 ): Promise<void> {
   const repo = 'embedded-protocol';
 
-  if (!options || 'version' in options) {
-    const version = options?.version ?? pkg['protocol-version'];
+  options ??= defaultVersionOption('protocol-version');
+  if ('version' in options) {
+    const version = options?.version;
     await downloadRelease({
       repo,
       assetUrl: `https://github.com/sass/${repo}/archive/${version}${ARCHIVE_EXTENSION}`,
@@ -127,8 +128,9 @@ export async function getDartSassEmbedded(
 ): Promise<void> {
   const repo = 'dart-sass-embedded';
 
-  if (!options || 'version' in options) {
-    const version = options?.version ?? pkg['compiler-version'];
+  options ??= defaultVersionOption('compiler-version');
+  if ('version' in options) {
+    const version = options?.version;
     await downloadRelease({
       repo,
       assetUrl:
@@ -281,6 +283,15 @@ function buildDartSassEmbedded(repoPath: string): void {
     cwd: repoPath,
     silent: true,
   });
+}
+
+// Given the name of a field in `package.json`, returns the default version
+// option described by that field.
+function defaultVersionOption(
+  pkgField: keyof typeof pkg
+): {version: string} | {ref: string} {
+  const version = pkg[pkgField] as string;
+  return version.endsWith('-dev') ? {ref: 'main'} : {version};
 }
 
 // Links or copies the contents of `source` into `destination`.


### PR DESCRIPTION
In order to depend on these, the package.json must use a `-dev` suffix
on the corresponding fields. This also blocks the automated release
process if this suffix exists.