### PR TITLE
Clone repos using https:// not git://

### DIFF
--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -230,7 +230,7 @@ function fetchRepo(options: {
     shell.exec(
       `git clone \
       --depth=1 \
-      git://github.com/sass/${options.repo} \
+      https://github.com/sass/${options.repo} \
       ${p.join(options.outPath, options.repo)}`,
       {silent: true}
     );


### PR DESCRIPTION
GitHub no longer supports the git:// protocol: https://github.blog/2021-09-01-improving-git-protocol-security-github/