### PR TITLE
Implement support for the sourceMapIncludeSources option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: npm run init
         run: |
           if [[ -d embedded-protocol ]]; then args=--protocol-path=embedded-protocol; fi
-          npm run init -- --no-compiler --api-path=language $args
+          npm run init -- --skip-compiler --api-path=language $args
 
       - run: npm run check
 

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -108,6 +108,7 @@ function newCompileRequest(
   request.setImportersList(importers.importers);
   request.setGlobalFunctionsList(Object.keys(options?.functions ?? {}));
   request.setSourceMap(!!options?.sourceMap);
+  request.setSourceMapIncludeSources(!!options?.sourceMapIncludeSources);
   request.setAlertColor(options?.alertColor ?? !!supportsColor.stdout);
   request.setAlertAscii(!!options?.alertAscii);
   request.setQuietDeps(!!options?.quietDeps);

--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -152,6 +152,7 @@ function convertOptions<sync extends 'sync' | 'async'>(
     functions,
     importers,
     sourceMap: wasSourceMapRequested(options),
+    sourceMapIncludeSources: options.sourceMapContents,
     loadPaths: importers ? undefined : options.includePaths,
     style: options.outputStyle as 'compressed' | 'expanded' | undefined,
     quietDeps: options.quietDeps,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sass-embedded",
   "version": "1.0.0-rc.1",
-  "protocol-version": "1.0.0-beta.16",
+  "protocol-version": "1.0.0",
   "compiler-version": "1.0.0-beta.16",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
   "repository": "sass/embedded-host-node",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sass-embedded",
   "version": "1.0.0-rc.1",
   "protocol-version": "1.0.0",
-  "compiler-version": "1.0.0-beta.16",
+  "compiler-version": "1.0.0-dev",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",


### PR DESCRIPTION
This also allows implement the sourceMapContents option of the legacy API.

Closes #101
https://github.com/sass/sass-spec/pull/1774
Depends on https://github.com/sass/dart-sass-embedded/pull/62