### PR TITLE
Fix the linking of embedded-compiler PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: npm run init
         run: |
           if [[ -d embedded-protocol ]]; then args=--protocol-path=embedded-protocol; fi
-          if [[ -d dart-sass-embedded ]]; then args=$args --compiler-path=dart-sass-embedded; fi
+          if [[ -d dart-sass-embedded ]]; then args="$args --compiler-path=dart-sass-embedded"; fi
           npm run init -- --api-path=language $args
 
       - run: npm run test
@@ -158,7 +158,7 @@ jobs:
       - name: npm run init
         run: |
           if [[ -d embedded-protocol ]]; then args=--protocol-path=embedded-protocol; fi
-          if [[ -d dart-sass-embedded ]]; then args=$args --compiler-path=dart-sass-embedded; fi
+          if [[ -d dart-sass-embedded ]]; then args="$args --compiler-path=dart-sass-embedded"; fi
           npm run init -- --api-path=language $args
 
       - name: Check out sass-spec


### PR DESCRIPTION
Without those quotes, `--compiler-path=dart-sass-embedded` is not of the variable value, but a separate command being run, due to the space.