### PR TITLE
Fix source map URLs for the legacy API

### DIFF
--- a/lib/src/legacy/importer.ts
+++ b/lib/src/legacy/importer.ts
@@ -170,7 +170,11 @@ export class LegacyImporterWrapper<sync extends 'sync' | 'async'>
   load(canonicalUrl: URL): ImporterResult | null {
     if (canonicalUrl.protocol === endOfLoadProtocol) {
       this.prev.pop();
-      return {contents: '', syntax: 'scss'};
+      return {
+        contents: '',
+        syntax: 'scss',
+        sourceMapUrl: new URL(endOfLoadProtocol),
+      };
     }
 
     if (canonicalUrl.protocol === 'file:') {
@@ -195,7 +199,7 @@ export class LegacyImporterWrapper<sync extends 'sync' | 'async'>
         this.prev.pop();
       }
 
-      return {contents, syntax};
+      return {contents, syntax, sourceMapUrl: canonicalUrl};
     }
 
     const lastContents = this.lastContents;
@@ -204,6 +208,7 @@ export class LegacyImporterWrapper<sync extends 'sync' | 'async'>
     return {
       contents: lastContents + this.endOfLoadImport,
       syntax: 'scss',
+      sourceMapUrl: canonicalUrl,
     };
   }
 

--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -246,17 +246,21 @@ function newLegacyResult(
       sourceMap.file = 'stdin.css';
     }
 
-    sourceMap.sources = sourceMap.sources.map(source => {
-      if (source.startsWith('file://')) {
-        return pathToUrlString(
-          p.relative(sourceMapDir, fileUrlToPathCrossPlatform(source))
-        );
-      } else if (source.startsWith('data:')) {
-        return 'stdin';
-      } else {
-        return source;
-      }
-    });
+    sourceMap.sources = sourceMap.sources
+      .filter(source => !source.startsWith(endOfLoadProtocol))
+      .map(source => {
+        if (source.startsWith('file://')) {
+          return pathToUrlString(
+            p.relative(sourceMapDir, fileUrlToPathCrossPlatform(source))
+          );
+        } else if (source.startsWith(legacyImporterProtocol)) {
+          return source.substring(legacyImporterProtocol.length);
+        } else if (source.startsWith('data:')) {
+          return 'stdin';
+        } else {
+          return source;
+        }
+      });
 
     sourceMapBytes = Buffer.from(JSON.stringify(sourceMap));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-embedded",
-  "version": "1.49.7",
+  "version": "1.49.8-dev",
   "protocol-version": "1.0.0",
   "compiler-version": "1.49.7",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",


### PR DESCRIPTION
If an importer was passed, these URLs were broken by our end-of-load
import injection. This fixes the issue by explicitly passing a
`sourceMapUrl` field which allows the wrapper to reconstruct the
correct URLs.

See https://github.com/webpack-contrib/sass-loader/issues/774#issuecomment-1039253270
See sass/sass-spec#1776