### PR TITLE
Don't crash when an empty importer list is passed to the legacy API

### DIFF
--- a/lib/src/legacy/importer.ts
+++ b/lib/src/legacy/importer.ts
@@ -71,8 +71,6 @@ export class LegacyImporterWrapper<sync extends 'sync' | 'async'>
   // the modern API, so we always return `null` in this case.
   private expectingRelativeLoad = true;
 
-  // TODO: Support prev from a load path
-
   constructor(
     private readonly self: LegacyPluginThis,
     private readonly callbacks: Array<LegacyImporter<sync>>,
@@ -220,6 +218,8 @@ export class LegacyImporterWrapper<sync extends 'sync' | 'async'>
     prev: string,
     {fromImport}: {fromImport: boolean}
   ): PromiseOr<LegacyImporterResult, sync> {
+    assert(this.callbacks.length > 0);
+
     const self: LegacyImporterThis = {...this.self, fromImport};
     self.options = {...self.options, context: self};
 

--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -134,19 +134,21 @@ function convertOptions<sync extends 'sync' | 'async'>(
     functions[signature] = wrapFunction(self, callback, sync);
   }
 
-  const importers = options.importer
-    ? [
-        new LegacyImporterWrapper(
-          self,
-          options.importer instanceof Array
-            ? options.importer
-            : [options.importer],
-          options.includePaths ?? [],
-          options.file ?? 'stdin',
-          sync
-        ),
-      ]
-    : undefined;
+  const importers =
+    options.importer &&
+    (!(options.importer instanceof Array) || options.importer.length > 0)
+      ? [
+          new LegacyImporterWrapper(
+            self,
+            options.importer instanceof Array
+              ? options.importer
+              : [options.importer],
+            options.includePaths ?? [],
+            options.file ?? 'stdin',
+            sync
+          ),
+        ]
+      : undefined;
 
   return {
     functions,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-embedded",
-  "version": "1.49.8",
+  "version": "1.49.9-dev",
   "protocol-version": "1.0.0",
   "compiler-version": "1.49.8",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",


### PR DESCRIPTION
See sass/sass-spec#1779