### PR TITLE
Do not output `no units` when converting SassNumber to String

### DIFF
--- a/lib/src/value/number.ts
+++ b/lib/src/value/number.ts
@@ -613,10 +613,16 @@ export class SassNumber extends Value {
         }
       }
 
+      const unitSize = newNumerators.size + newDenominators.size;
       return valueError(
         `Expected $this to have ${
-          newNumerators.size + newDenominators.size > 1 ? 'units' : 'unit'
-        } ${unitString(newNumerators, newDenominators)}.`,
+          unitSize === 0
+            ? 'no units'
+            : `unit${unitSize > 1 ? 's' : ''} ${unitString(
+                newNumerators,
+                newDenominators
+              )}`
+        }.`,
         params.name
       );
     };
@@ -684,7 +690,7 @@ function unitString(
   denominators: List<string>
 ): string {
   if (numerators.isEmpty() && denominators.isEmpty()) {
-    return 'no units';
+    return '';
   }
 
   if (denominators.isEmpty()) {


### PR DESCRIPTION
This PR solves one of the two issues reported in #112.