### PR TITLE
Add support for npm installation (cross-platform) config

### DIFF
--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -16,7 +16,8 @@ shell.config.fatal = true;
 // The current platform's operating system. Throws if the operating system
 // is not supported by Dart Sass Embedded.
 const OS: 'linux' | 'macos' | 'windows' = (() => {
-  switch (process.platform) {
+  const platform = process.env.npm_config_platform || process.platform;
+  switch (platform) {
     case 'linux':
       return 'linux';
     case 'darwin':
@@ -24,14 +25,15 @@ const OS: 'linux' | 'macos' | 'windows' = (() => {
     case 'win32':
       return 'windows';
     default:
-      throw Error(`Platform ${process.platform} is not supported.`);
+      throw Error(`Platform ${platform} is not supported.`);
   }
 })();
 
 // The current platform's architecture. Throws if the architecture is not
 // supported by Dart Sass Embedded.
 const ARCH: 'ia32' | 'x64' | 'arm64' = (() => {
-  switch (process.arch) {
+  const arch = process.env.npm_config_arch || process.arch;
+  switch (arch) {
     case 'ia32':
       return 'ia32';
     case 'x86':
@@ -41,7 +43,7 @@ const ARCH: 'ia32' | 'x64' | 'arm64' = (() => {
     case 'arm64':
       return 'arm64';
     default:
-      throw Error(`Architecure ${process.arch} is not supported.`);
+      throw Error(`Architecure ${arch} is not supported.`);
   }
 })();
 


### PR DESCRIPTION
This change enables to install package for different target platform/architecture.

For example on MacOS install Linux binary:
```
npm install  --arch=x64 --platform=linux sass-embedded
```
It's useful when you need to (cross-)build deployment artifact.


Inspired by sharp https://github.com/lovell/sharp/blob/d0c8e9564163cb8d1e1096c503f0c03d906f2666/lib/platform.js#L8