### PR TITLE
Avoid resolving imports relative to working directory for compileString

### DIFF
--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -2,6 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import * as p from 'path';
 import {Observable} from 'rxjs';
 import * as supportsColor from 'supports-color';
 
@@ -17,6 +18,7 @@ import {MessageTransformer} from './message-transformer';
 import {PacketTransformer} from './packet-transformer';
 import {SyncEmbeddedCompiler} from './sync-compiler';
 import {deprotofySourceSpan} from './deprotofy-span';
+import {legacyImporterProtocol} from './legacy/importer';
 
 export function compile(
   path: string,
@@ -87,10 +89,17 @@ function newCompileStringRequest(
   input.setSource(source);
   input.setSyntax(utils.protofySyntax(options?.syntax ?? 'scss'));
 
-  if (options?.url) input.setUrl(options.url.toString());
+  const url = options?.url?.toString();
+  if (url && url !== legacyImporterProtocol) {
+    input.setUrl(url);
+  }
 
   if (options && 'importer' in options && options.importer) {
     input.setImporter(importers.register(options.importer));
+  } else if (url === legacyImporterProtocol) {
+    const importer = new proto.InboundMessage.CompileRequest.Importer();
+    importer.setPath(p.resolve('.'));
+    input.setImporter(importer);
   }
 
   const request = newCompileRequest(importers, options);

--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -172,7 +172,9 @@ function convertStringOptions<sync extends 'sync' | 'async'>(
 
   return {
     ...modernOptions,
-    url: options.file ? pathToFileURL(options.file) : undefined,
+    url: options.file
+      ? pathToFileURL(options.file)
+      : new URL(legacyImporterProtocol),
     importer: modernOptions.importers ? modernOptions.importers[0] : undefined,
     syntax: options.indentedSyntax ? 'indented' : 'scss',
   };


### PR DESCRIPTION
This PR fixes https://github.com/sass/dart-sass-embedded/issues/82.