### PR TITLE
Set a FileSystemImporter if custom importer is not given for legacy API

### DIFF
--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -172,7 +172,9 @@ function convertStringOptions<sync extends 'sync' | 'async'>(
 
   return {
     ...modernOptions,
-    url: options.file ? pathToFileURL(options.file) : undefined,
+    url: options.file
+      ? pathToFileURL(options.file)
+      : new URL(legacyImporterProtocol),
     importer: modernOptions.importers ? modernOptions.importers[0] : undefined,
     syntax: options.indentedSyntax ? 'indented' : 'scss',
   };


### PR DESCRIPTION
Fixes legacy API in https://github.com/sass/dart-sass-embedded/pull/83.

See https://github.com/sass/sass-spec/pull/1785
See sass/dart-sass-embedded#83