### PR TITLE
Bump the dependency on the embedded compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sass-embedded",
   "version": "1.50.0",
   "protocol-version": "1.0.0",
-  "compiler-version": "1.50.0",
+  "compiler-version": "1.50.1-dev",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",


### PR DESCRIPTION
This should have been done as part of #128.