### PR TITLE
feat: support reading proxy from env

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "buffer-builder": "^0.2.0",
     "extract-zip": "^2.0.1",
     "google-protobuf": "^3.11.4",
+    "https-proxy-agent": "^5.0.1",
     "immutable": "^4.0.0",
     "node-fetch": "^2.6.0",
     "rxjs": "^7.4.0",

--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -5,6 +5,7 @@
 import extractZip = require('extract-zip');
 import {promises as fs, existsSync, mkdirSync} from 'fs';
 import fetch from 'node-fetch';
+import {HttpsProxyAgent} from 'https-proxy-agent';
 import * as p from 'path';
 import * as shell from 'shelljs';
 import {extract as extractTar} from 'tar';
@@ -188,8 +189,11 @@ async function downloadRelease(options: {
   outPath: string;
 }): Promise<void> {
   console.log(`Downloading ${options.repo} release asset.`);
+  const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy;
+  const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
   const response = await fetch(options.assetUrl, {
     redirect: 'follow',
+    agent,
   });
   if (!response.ok) {
     throw Error(


### PR DESCRIPTION
Support reading proxy from environtment variables, as sometimes downloading from github.com fails.

Reading priority:
- HTTPS_PROXY
- HTTP_PROXY
- https_proxy
- http_proxy

Use `https-proxy-agent` under the hood.