### PR TITLE
feat: Allow to change the Download Mirror, enabling corporate proxies… … and mirrors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,30 @@ library as a stand-alone package at some point in the future.
 [synchronous message-passing library]: https://github.com/sass/embedded-host-node/blob/main/lib/src/sync-process/sync-message-port.ts
 [`Atomics.wait()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait
 
+## Installation options
+
+sass-embedded supports options to change the installation method.
+
+Each option can be configured in the `sass-embedded` section of your `package.json`:
+
+```json
+{
+  "name": "your-package",
+  "version": "0.0.1",
+  "sass-embedded": {
+    "downloadMirror": "https://some.example.com/mirror"
+  }
+}
+```
+
+Also as an environment variable:
+
+```sh
+export SASS_EMBEDDED_DOWNLOAD_MIRROR="https://some.example.com/mirror"
+```
+
+**Note that you have to run `npm install sass-embedded` to re-install sass-embedded itself, if you change any of these options.**
+
 ---
 
 Disclaimer: this is not an official Google product.

--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -78,9 +78,11 @@ export async function getEmbeddedProtocol(
   options ??= defaultVersionOption('protocol-version');
   if ('version' in options) {
     const version = options?.version;
+    const downloadMirror = process.env.SASS_EMBEDDED_DOWNLOAD_MIRROR || process.env.npm_config_sass_embedded_download_mirror || 'https://github.com';
+
     await downloadRelease({
       repo,
-      assetUrl: `https://github.com/sass/${repo}/archive/${version}${ARCHIVE_EXTENSION}`,
+      assetUrl: `${downloadMirror}/sass/${repo}/archive/${version}${ARCHIVE_EXTENSION}`,
       outPath: BUILD_PATH,
     });
     fs.rename(
@@ -128,10 +130,12 @@ export async function getDartSassEmbedded(
   options ??= defaultVersionOption('compiler-version');
   if ('version' in options) {
     const version = options?.version;
+    const downloadMirror = process.env.SASS_EMBEDDED_DOWNLOAD_MIRROR || process.env.npm_config_sass_embedded_download_mirror || 'https://github.com';
+
     await downloadRelease({
       repo,
       assetUrl:
-        `https://github.com/sass/${repo}/releases/download/` +
+        `${downloadMirror}/sass/${repo}/releases/download/` +
         `${version}/sass_embedded-${version}-` +
         `${OS}-${ARCH}${ARCHIVE_EXTENSION}`,
       outPath,


### PR DESCRIPTION
Allowing to set an installation variable in the package.json sass-embedded/downloadMirror, which allows to replace the default download location https://github.com/.

This is required in many corporate setups, where access to internet resources is restricted.