### PR TITLE
Fix `isEmpty()` call

### DIFF
--- a/lib/src/value/number.ts
+++ b/lib/src/value/number.ts
@@ -601,7 +601,7 @@ export class SassNumber extends Value {
 
       // For single numerators, throw a detailed error with info about which unit
       // types would have been acceptable.
-      if (newNumerators.size === 1 && newDenominators.isEmpty) {
+      if (newNumerators.size === 1 && newDenominators.isEmpty()) {
         const type = typesByUnit[newNumerators.get(0)!];
         if (type) {
           return valueError(


### PR DESCRIPTION
This PR fixes the following error:

```
lib/src/value/number.ts:604:39 - error TS2774: This condition will always return true since this function is always defined. Did you mean to call it instead?

604       if (newNumerators.size === 1 && newDenominators.isEmpty) {
                                          ~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in lib/src/value/number.ts:604
```