### PR TITLE
Await fs promises to avoid EPERMs

### DIFF
--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -85,7 +85,7 @@ export async function getEmbeddedProtocol(
       assetUrl: `https://github.com/sass/${repo}/archive/${version}${ARCHIVE_EXTENSION}`,
       outPath: BUILD_PATH,
     });
-    fs.rename(
+    await fs.rename(
       p.join(BUILD_PATH, `${repo}-${version}`),
       p.join(BUILD_PATH, repo)
     );
@@ -138,7 +138,7 @@ export async function getDartSassEmbedded(
         `${OS}-${ARCH}${ARCHIVE_EXTENSION}`,
       outPath,
     });
-    fs.rename(p.join(outPath, 'sass_embedded'), p.join(outPath, repo));
+    await fs.rename(p.join(outPath, 'sass_embedded'), p.join(outPath, repo));
     return;
   }
 
@@ -304,7 +304,7 @@ async function link(source: string, destination: string): Promise<void> {
   } else {
     console.log(`Linking ${source} into ${destination}.`);
     // Symlinking doesn't play nice with Jasmine's test globbing on Windows.
-    fs.symlink(p.resolve(source), destination);
+    await fs.symlink(p.resolve(source), destination);
   }
 }
 


### PR DESCRIPTION
Cherry-picking https://github.com/sass/embedded-host-node/pull/135/commits/01d5d1220bd410da254d8ce975978ee83ac9f214 from #135 to unblock failed CI tests.