### PR TITLE
Don't use scoped platform-specific packages

### DIFF
--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -10,11 +10,10 @@ import {isErrnoException} from './utils';
 export const compilerPath = (() => {
   try {
     return require.resolve(
-      `@sass-embedded/${process.platform}-${
-        process.arch
-      }/dart-sass-embedded/dart-sass-embedded${
+      `sass-embedded-${process.platform}-${process.arch}/` + 
+        'dart-sass-embedded/dart-sass-embedded' + (
         process.platform === 'win32' ? '.bat' : ''
-      }`
+      )
     );
   } catch (e: unknown) {
     if (!(isErrnoException(e) && e.code === 'MODULE_NOT_FOUND')) {
@@ -38,7 +37,7 @@ export const compilerPath = (() => {
   throw new Error(
     "Embedded Dart Sass couldn't find the embedded compiler executable. " +
       'Please make sure the optional dependency ' +
-      '@sass-embedded/${process.platform}-${process.arch} is installed in ' +
+      'sass-embedded-${process.platform}-${process.arch} is installed in ' +
       'node_modules.'
   );
 })();

--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -10,10 +10,9 @@ import {isErrnoException} from './utils';
 export const compilerPath = (() => {
   try {
     return require.resolve(
-      `sass-embedded-${process.platform}-${process.arch}/` + 
-        'dart-sass-embedded/dart-sass-embedded' + (
-        process.platform === 'win32' ? '.bat' : ''
-      )
+      `sass-embedded-${process.platform}-${process.arch}/` +
+        'dart-sass-embedded/dart-sass-embedded' +
+        (process.platform === 'win32' ? '.bat' : '')
     );
   } catch (e: unknown) {
     if (!(isErrnoException(e) && e.code === 'MODULE_NOT_FOUND')) {

--- a/npm/darwin-arm64/README.md
+++ b/npm/darwin-arm64/README.md
@@ -1,3 +1,3 @@
-# `@sass-embedded/darwin-arm64`
+# `sass-embedded-darwin-arm64`
 
 This is the **darwin-arm64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sass-embedded/darwin-arm64",
+  "name": "sass-embedded-darwin-arm64",
   "version": "1.54.4",
   "description": "The darwin-arm64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",

--- a/npm/darwin-x64/README.md
+++ b/npm/darwin-x64/README.md
@@ -1,3 +1,3 @@
-# `@sass-embedded/darwin-x64`
+# `sass-embedded-darwin-x64`
 
 This is the **darwin-x64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sass-embedded/darwin-x64",
+  "name": "sass-embedded-darwin-x64",
   "version": "1.54.4",
   "description": "The darwin-x64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",

--- a/npm/linux-arm64/README.md
+++ b/npm/linux-arm64/README.md
@@ -1,3 +1,3 @@
-# `@sass-embedded/linux-arm64`
+# `sass-embedded-linux-arm64`
 
 This is the **linux-arm64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sass-embedded/linux-arm64",
+  "name": "sass-embedded-linux-arm64",
   "version": "1.54.4",
   "description": "The linux-arm64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",

--- a/npm/linux-ia32/README.md
+++ b/npm/linux-ia32/README.md
@@ -1,3 +1,3 @@
-# `@sass-embedded/linux-ia32`
+# `sass-embedded-linux-ia32`
 
 This is the **linux-ia32** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-ia32/package.json
+++ b/npm/linux-ia32/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sass-embedded/linux-ia32",
+  "name": "sass-embedded-linux-ia32",
   "version": "1.54.4",
   "description": "The linux-ia32 binary for sass-embedded",
   "repository": "sass/embedded-host-node",

--- a/npm/linux-x64/README.md
+++ b/npm/linux-x64/README.md
@@ -1,3 +1,3 @@
-# `@sass-embedded/linux-x64`
+# `sass-embedded-linux-x64`
 
 This is the **linux-x64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sass-embedded/linux-x64",
+  "name": "sass-embedded-linux-x64",
   "version": "1.54.4",
   "description": "The linux-x64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",

--- a/npm/win32-ia32/README.md
+++ b/npm/win32-ia32/README.md
@@ -1,3 +1,3 @@
-# `@sass-embedded/win32-ia32`
+# `sass-embedded-win32-ia32`
 
 This is the **win32-ia32** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/win32-ia32/package.json
+++ b/npm/win32-ia32/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sass-embedded/win32-ia32",
+  "name": "sass-embedded-win32-ia32",
   "version": "1.54.4",
   "description": "The win32-ia32 binary for sass-embedded",
   "repository": "sass/embedded-host-node",

--- a/npm/win32-x64/README.md
+++ b/npm/win32-x64/README.md
@@ -1,3 +1,3 @@
-# `@sass-embedded/win32-x64`
+# `sass-embedded-win32-x64`
 
 This is the **win32-x64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sass-embedded/win32-x64",
+  "name": "sass-embedded-win32-x64",
   "version": "1.54.4",
   "description": "The win32-x64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "test": "jest"
   },
   "optionalDependencies": {
-    "@sass-embedded/linux-arm64": "1.54.5",
-    "@sass-embedded/linux-ia32": "1.54.5",
-    "@sass-embedded/linux-x64": "1.54.5",
-    "@sass-embedded/darwin-arm64": "1.54.5",
-    "@sass-embedded/darwin-x64": "1.54.5",
-    "@sass-embedded/win32-ia32": "1.54.5",
-    "@sass-embedded/win32-x64": "1.54.5"
+    "sass-embedded-linux-arm64": "1.54.5",
+    "sass-embedded-linux-ia32": "1.54.5",
+    "sass-embedded-linux-x64": "1.54.5",
+    "sass-embedded-darwin-arm64": "1.54.5",
+    "sass-embedded-darwin-x64": "1.54.5",
+    "sass-embedded-win32-ia32": "1.54.5",
+    "sass-embedded-win32-x64": "1.54.5"
   },
   "dependencies": {
     "buffer-builder": "^0.2.0",

--- a/tool/prepare-optional-release.ts
+++ b/tool/prepare-optional-release.ts
@@ -14,7 +14,7 @@ const argv = yargs(process.argv.slice(2))
       'Directory name under `npm` directory that contains optional dependencies.',
     demandOption: true,
     choices: Object.keys(pkg.optionalDependencies).map(
-      name => name.split('@sass-embedded/')[1]
+      name => name.split('sass-embedded-')[1]
     ),
   })
   .parseSync();


### PR DESCRIPTION
These require setting up NPM org stuff that's more of a hassle than
it's worth.