### PR TITLE
Fix error message for optional dependency

### DIFF
--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -36,7 +36,7 @@ export const compilerPath = (() => {
   throw new Error(
     "Embedded Dart Sass couldn't find the embedded compiler executable. " +
       'Please make sure the optional dependency ' +
-      'sass-embedded-${process.platform}-${process.arch} is installed in ' +
+      `sass-embedded-${process.platform}-${process.arch} is installed in ` +
       'node_modules.'
   );
 })();


### PR DESCRIPTION
It should be a template string instead of a normal string to print the correct message.