### PR TITLE
Fix function name parsing with whitespace

### DIFF
--- a/lib/src/function-registry.ts
+++ b/lib/src/function-registry.ts
@@ -37,7 +37,7 @@ export class FunctionRegistry<sync extends 'sync' | 'async'> {
         throw new Error(`options.functions: "${signature}" is missing "("`);
       }
 
-      this.functionsByName.set(signature.substring(0, openParen).trim(), fn);
+      this.functionsByName.set(signature.substring(0, openParen).trimEnd(), fn);
     }
   }
 

--- a/lib/src/function-registry.ts
+++ b/lib/src/function-registry.ts
@@ -57,11 +57,11 @@ export class FunctionRegistry<sync extends 'sync' | 'async'> {
   call(
     request: OutboundMessage.FunctionCallRequest
   ): PromiseOr<InboundMessage.FunctionCallResponse, sync> {
-    const protofier = new Protofier(this);
-    const fn = this.get(request);
-
     return catchOr(
       () => {
+        const protofier = new Protofier(this);
+        const fn = this.get(request);
+
         return thenOr(
           fn(
             request

--- a/lib/src/function-registry.ts
+++ b/lib/src/function-registry.ts
@@ -37,7 +37,7 @@ export class FunctionRegistry<sync extends 'sync' | 'async'> {
         throw new Error(`options.functions: "${signature}" is missing "("`);
       }
 
-      this.functionsByName.set(signature.substring(0, openParen), fn);
+      this.functionsByName.set(signature.substring(0, openParen).trim(), fn);
     }
   }
 


### PR DESCRIPTION
This PR fixes function name parsing when whitespace exists between function name and `(`.

The following code works on sass but not sass-embedded due to function name being incorrectly parsed as `x ` (with extra whitespace at the end):

```
const sass = require('sass-embedded')

const result = sass.compileString('a{b:x()}', {
  functions: {
    'x ()': function () { return sass.sassTrue }
  }
})

console.log(result)
```

https://github.com/sass/sass-spec/pull/1854