### PR TITLE
Prefer a local development compiler to an installed dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,19 @@ jobs:
         uses: sass/clone-linked-repo@v1
         with: {repo: sass/embedded-protocol, default-ref: null}
 
-      - name: Check out the embedded compiler
-        uses: sass/clone-linked-repo@v1
-        with: {repo: sass/dart-sass-embedded, default-ref: null}
-
       - name: Check out Dart Sass
+        id: clone-dart-sass
         uses: sass/clone-linked-repo@v1
         with: {repo: sass/dart-sass, default-ref: null}
+
+      - name: Check out the embedded compiler
+        uses: sass/clone-linked-repo@v1
+        with:
+          repo: sass/dart-sass-embedded
+          # If we check out a specific version of Dart Sass, always check out
+          # the embedded compiler as well so we can actually use that Dart Sass
+          # version.
+          default-ref: ${{ !steps.clone-dart-sass.skip && 'main' || null }}
 
       - name: Link the embedded compiler to Dart Sass
         run: |
@@ -135,13 +141,19 @@ jobs:
         uses: sass/clone-linked-repo@v1
         with: {repo: sass/embedded-protocol, default-ref: null}
 
-      - name: Check out the embedded compiler
-        uses: sass/clone-linked-repo@v1
-        with: {repo: sass/dart-sass-embedded, default-ref: null}
-
       - name: Check out Dart Sass
+        id: clone-dart-sass
         uses: sass/clone-linked-repo@v1
         with: {repo: sass/dart-sass, default-ref: null}
+
+      - name: Check out the embedded compiler
+        uses: sass/clone-linked-repo@v1
+        with:
+          repo: sass/dart-sass-embedded
+          # If we check out a specific version of Dart Sass, always check out
+          # the embedded compiler as well so we can actually use that Dart Sass
+          # version.
+          default-ref: ${{ !steps.clone-dart-sass.skip && 'main' || null }}
 
       - name: Link the embedded compiler to Dart Sass
         run: |

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -153,6 +153,7 @@ async function compileRequestAsync(
 ): Promise<CompileResult> {
   const functions = new FunctionRegistry(options?.functions);
   const embeddedCompiler = new AsyncEmbeddedCompiler();
+  embeddedCompiler.stderr$.subscribe(data => process.stderr.write(data));
 
   try {
     const dispatcher = createDispatcher<'async'>(
@@ -198,6 +199,7 @@ function compileRequestSync(
 ): CompileResult {
   const functions = new FunctionRegistry(options?.functions);
   const embeddedCompiler = new SyncEmbeddedCompiler();
+  embeddedCompiler.stderr$.subscribe(data => process.stderr.write(data));
 
   try {
     const dispatcher = createDispatcher<'sync'>(

--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -8,18 +8,6 @@ import {isErrnoException} from './utils';
 
 /** The path to the embedded compiler executable. */
 export const compilerPath = (() => {
-  try {
-    return require.resolve(
-      `sass-embedded-${process.platform}-${process.arch}/` +
-        'dart-sass-embedded/dart-sass-embedded' +
-        (process.platform === 'win32' ? '.bat' : '')
-    );
-  } catch (e: unknown) {
-    if (!(isErrnoException(e) && e.code === 'MODULE_NOT_FOUND')) {
-      throw e;
-    }
-  }
-
   // find for development
   for (const path of ['vendor', '../../../lib/src/vendor']) {
     const executable = p.resolve(
@@ -31,6 +19,18 @@ export const compilerPath = (() => {
     );
 
     if (fs.existsSync(executable)) return executable;
+  }
+
+  try {
+    return require.resolve(
+      `sass-embedded-${process.platform}-${process.arch}/` +
+        'dart-sass-embedded/dart-sass-embedded' +
+        (process.platform === 'win32' ? '.bat' : '')
+    );
+  } catch (e: unknown) {
+    if (!(isErrnoException(e) && e.code === 'MODULE_NOT_FOUND')) {
+      throw e;
+    }
   }
 
   throw new Error(

--- a/lib/src/sync-compiler.ts
+++ b/lib/src/sync-compiler.ts
@@ -21,6 +21,9 @@ export class SyncEmbeddedCompiler {
   /** The buffers emitted by the child process's stderr. */
   readonly stderr$ = new Subject<Buffer>();
 
+  /** Whether the underlying compiler has already exited. */
+  private exited = false;
+
   /** Writes `buffer` to the child process's stdin. */
   writeStdin(buffer: Buffer): void {
     this.process.stdin.write(buffer);
@@ -38,14 +41,15 @@ export class SyncEmbeddedCompiler {
         return true;
 
       case 'exit':
+        this.exited = true;
         return false;
     }
   }
 
   /** Blocks until the underlying process exits. */
   yieldUntilExit(): void {
-    while (this.yield()) {
-      // Any events will be handled by `this.yield()`.
+    while (!this.exited) {
+      this.yield();
     }
   }
 


### PR DESCRIPTION
This also fixes several issues that made it much harder to debug
compiler failures.

See https://github.com/sass/dart-sass/pull/1848
See https://github.com/sass/sass-spec/pull/1856