### PR TITLE
Use Dart Sass and the embedded compiler from HEAD by default

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+build/
+dist/
+language/
+embedded-protocol/
+lib/src/vendor/
+**/*.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./node_modules/gts/",
+  "rules": {
+    "prefer-const": ["error", {"destructuring": "all"}]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,209 @@
+name: CI
+
+defaults:
+  run: {shell: bash}
+
+env:
+  PROTOC_VERSION: 3.x
+  DEFAULT_NODE_VERSION: 15.x # If changing this, also change jobs.tests.strategy.matrix.node_version
+
+on:
+  push:
+    branches: [main, feature.*]
+    tags: ['**']
+  pull_request:
+
+jobs:
+  static_analysis:
+    name: Static analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          check-latest: true
+      - uses: arduino/setup-protoc@v1
+        with:
+          version: ${{ env.PROTOC_VERSION }}
+          repo-token: '${{ github.token }}'
+
+      - name: Check out the embedded protocol
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/embedded-protocol, default-ref: null}
+
+      - name: Check out the JS API definition
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/sass, path: language}
+
+      - run: npm install
+      - name: npm run init
+        run: |
+          if [[ -d embedded-protocol ]]; then args=--protocol-path=embedded-protocol; fi
+          npm run init -- --skip-compiler --api-path=language $args
+
+      - run: npm run check
+
+  tests:
+    name: 'Tests | Node ${{ matrix.node-version }} | ${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}-latest
+
+    strategy:
+      matrix:
+        os: [ubuntu, macos, windows]
+        node-version: [15.x, 14.x, 12.x] # If changing this, also change env.DEFAULT_NODE_VERSION
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          check-latest: true
+      - uses: frenck/action-setup-yq@v1
+        with: {version: v4.30.5} # frenck/action-setup-yq#35
+      - uses: arduino/setup-protoc@v1
+        with:
+          version: ${{ env.PROTOC_VERSION }}
+          repo-token: '${{ github.token }}'
+      - uses: dart-lang/setup-dart@v1
+        with: {sdk: stable}
+      - run: dart --version
+
+      - name: Check out the embedded protocol
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/embedded-protocol, default-ref: null}
+
+      - name: Check out Dart Sass
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/dart-sass}
+
+      - name: Check out the embedded compiler
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/dart-sass-embedded}
+
+      - name: Link the embedded compiler to Dart Sass
+        run: |
+          yq -i '.dependency_overrides.sass = {"path": "../dart-sass"}' \
+              dart-sass-embedded/pubspec.yaml
+
+      - name: Check out the JS API definition
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/sass, path: language}
+
+      - run: npm install
+      - name: npm run init
+        run: |
+          if [[ -d embedded-protocol ]]; then args=--protocol-path=embedded-protocol; fi
+          npm run init -- --compiler-path=dart-sass-embedded --api-path=language $args
+
+      - run: npm run test
+
+  # The versions should be kept up-to-date with the latest LTS Node releases.
+  # They next need to be rotated October 2021. See
+  # https://github.com/nodejs/Release.
+  sass_spec:
+    name: 'JS API Tests | Node ${{ matrix.node_version }} | ${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows, macos]
+        node_version: [16]
+        include:
+          # Include LTS versions on Ubuntu
+          - os: ubuntu
+            node_version: 14
+          - os: ubuntu
+            node_version: 12
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+        with: {sdk: stable}
+      - uses: actions/setup-node@v2
+        with: {node-version: "${{ matrix.node_version }}"}
+      - uses: frenck/action-setup-yq@v1
+        with: {version: v4.30.5} # frenck/action-setup-yq#35
+      - uses: arduino/setup-protoc@v1
+        with:
+          version: ${{ env.PROTOC_VERSION }}
+          repo-token: '${{ github.token }}'
+
+      - name: Check out the embedded protocol
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/embedded-protocol, default-ref: null}
+
+      - name: Check out Dart Sass
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/dart-sass}
+
+      - name: Check out the embedded compiler
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/dart-sass-embedded}
+
+      - name: Link the embedded compiler to Dart Sass
+        run: |
+          yq -i '.dependency_overrides.sass = {"path": "../dart-sass"}' \
+              dart-sass-embedded/pubspec.yaml
+
+      - name: Check out the JS API definition
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/sass, path: language}
+
+      - run: npm install
+      - name: npm run init
+        run: |
+          if [[ -d embedded-protocol ]]; then args=--protocol-path=embedded-protocol; fi
+          npm run init -- --compiler-path=dart-sass-embedded --api-path=language $args
+
+      - name: Check out sass-spec
+        uses: sass/clone-linked-repo@v1
+        with: {repo: sass/sass-spec}
+
+      - name: Install sass-spec dependencies
+        run: npm install
+        working-directory: sass-spec
+
+      - name: Compile
+        run: |
+          npm run compile
+          ln -s {`pwd`/,dist/}lib/src/vendor/dart-sass-embedded
+
+      - name: Run tests
+        run: npm run js-api-spec -- --sassPackage .. --sassSassRepo ../language
+        working-directory: sass-spec
+
+  deploy_npm:
+    name: Deploy npm
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/') && github.repository == 'sass/embedded-host-node'"
+    needs: [static_analysis, tests, sass_spec]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          check-latest: true
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+
+      - name: "Check we're not using a -dev version of the embedded protocol"
+        run: jq -r '.["protocol-version"]' package.json | grep -qv -- '-dev$'
+      - name: "Check we're not using a -dev version of the embedded compiler"
+        run: jq -r '.["compiler-version"]' package.json | grep -qv -- '-dev$'
+
+      - name: Publish optional dependencies
+        env:
+          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
+        run: |
+          for pkg in linux-arm linux-arm64 linux-ia32 linux-x64 darwin-arm64 darwin-x64 win32-ia32 win32-x64; do
+            npx ts-node ./tool/prepare-optional-release.ts --package=$pkg && npm publish ./npm/$pkg
+          done
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+.DS_Store
+build
+dist
+lib/src/vendor
+node_modules
+npm-debug.log*
+package-lock.json
+test/sandbox
+npm/*/dart-sass-embedded/
+
+# Editors
+.idea
+.vscode
+*.njsproj
+*.ntvs*
+*.sln
+*.suo
+*.sw?

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('gts/.prettierrc.json'),
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2761 @@
+## 1.56.2
+
+### Embedded Sass
+
+* The embedded compiler now supports version 1.2.0 of [the embedded
+  protocol](https://github.com/sass/embedded-protocol).
+
+## 1.56.1
+
+### Embedded Sass
+
+* Importer results now validate that `contents` is actually a string and whether
+  `sourceMapUrl` is an absolute URL.
+
+## 1.56.0
+
+* **Potentially breaking change:** To match the CSS spec, SassScript expressions
+  beginning with `not` or `(` are no longer supported at the beginning of
+  parenthesized sections of media queries. For example,
+
+  ```scss
+  @media (width >= 500px) and (not (grid))
+  ```
+
+  will now be emitted unchanged, instead of producing
+
+  ```scss
+  @media (width >= 500px) and (false)
+  ```
+
+  See [the Sass website](https://sass-lang.com/d/media-logic) for details.
+
+* **Potentially breaking bug fix:** Angle units like `rad` or `turn` are now
+  properly converted to equivalent `deg` values for `hsl()`, `hsla()`,
+  `adjust-hue()`, `color.adjust()`, and `color.change()`.
+
+  See [the Sass website](https://sass-lang.com/d/function-units#hue) for
+  details.
+
+* Fix indentation for selectors that span multiple lines in a `@media` query.
+
+* Emit a deprecation warning when passing `$alpha` values with units to
+  `color.adjust()` or `color.change()`. This will be an error in Dart Sass
+  2.0.0.
+
+  See [the Sass website](https://sass-lang.com/d/function-units#alpha) for
+  details.
+
+* Emit a deprecation warning when passing a `$weight` value with no units or
+  with units other than `%` to `color.mix()`. This will be an error in Dart Sass
+  2.0.0.
+
+  See [the Sass website](https://sass-lang.com/d/function-units#weight) for
+  details.
+
+* Emit a deprecation warning when passing `$n` values with units to `list.nth()`
+  or `list.set-nth()`. This will be an error in Dart Sass 2.0.0.
+
+  See [the Sass website](https://sass-lang.com/d/function-units#index) for
+  details.
+
+* Improve existing deprecation warnings to wrap `/`-as-division suggestions in
+  `calc()` expressions.
+
+* Properly mark the warning for passing numbers with units to `random()` as a
+  deprecation warning.
+
+* Fix a bug where `@extend` could behave unpredicatably when used along with
+  `meta.load-css()` and shared modules that contained no CSS themselves but
+  loaded CSS from other modules.
+
+### Dart API
+
+* Emit a deprecation warning when passing a `sassIndex` with units to
+  `Value.sassIndexToListIndex()`. This will be an error in Dart Sass 2.0.0.
+
+### JS API
+
+* Importer results now validate whether `contents` is actually a string type.
+
+* Importer result argument errors are now rendered correctly.
+
+## 1.55.0
+
+* **Potentially breaking bug fix:** Sass numbers are now universally stored as
+  64-bit floating-point numbers, rather than sometimes being stored as integers.
+  This will generally make arithmetic with very large numbers more reliable and
+  more consistent across platforms, but it does mean that numbers between nine
+  quadrillion and nine quintillion will no longer be represented with full
+  accuracy when compiling Sass on the Dart VM.
+
+* **Potentially breaking bug fix:** Sass equality is now properly [transitive].
+  Two numbers are now considered equal (after doing unit conversions) if they
+  round to the same `1e-11`th. Previously, numbers were considered equal if they
+  were within `1e-11` of one another, which led to some circumstances where `$a
+  == $b` and `$b == $c` but `$a != $b`.
+
+[transitive]: https://en.wikipedia.org/wiki/Transitive_property
+
+* **Potentially breaking bug fix:** Various functions in `sass:math` no longer
+  treat floating-point numbers that are very close (but not identical) to
+  integers as integers. Instead, these functions now follow the floating-point
+  specification exactly. For example, `math.pow(0.000000000001, -1)` now returns
+  `1000000000000` instead of `Infinity`.
+
+* Emit a deprecation warning for `$a -$b` and `$a +$b`, since these look like
+  they could be unary operations but they're actually parsed as binary
+  operations. Either explicitly write `$a - $b` or `$a (-$b)`. See
+  https://sass-lang.com/d/strict-unary for more details.
+
+### Dart API
+
+* Add an optional `argumentName` parameter to `SassScriptException()` to make it
+  easier to throw exceptions associated with particular argument names.
+
+* Most APIs that previously returned `num` now return `double`. All APIs
+  continue to _accept_ `num`, although in Dart 2.0.0 these APIs will be changed
+  to accept only `double`.
+
+### JS API
+
+* Fix a bug in which certain warning spans would not have their properties
+  accessible by the JS API.
+
+## 1.54.9
+
+* Fix an incorrect span in certain `@media` query deprecation warnings.
+
+## 1.54.8
+
+* No user-visible changes.
+
+## 1.54.7
+
+* Add support for 32-bit ARM releases on Linux.
+
+## 1.54.6
+
+* Fix a bug where a `@media` query could be incorrectly omitted from a
+  stylesheet if it had multiple levels of nested `@media` queries within it
+  *and* the inner queries were mergeable but the outer query was not.
+
+## 1.54.5
+
+* Properly consider `a ~ c` to be a superselector of `a ~ b ~ c` and `a + b +
+  c`.
+
+* Properly consider `b > c` to be a superselector of `a > b > c`, and similarly
+  for other combinators.
+
+* Properly calculate specificity for selector pseudoclasses.
+
+* Deprecate use of `random()` when `$limit` has units to make it explicit that
+   `random()` currently ignores units. A future version will no longer ignore
+  units.
+
+* Don't throw an error when the same module is `@forward`ed multiple times
+  through a configured module.
+
+### Embedded Sass
+
+* Rather than downloading the embedded compiler for the local platform on
+  install, the `sass-embedded` npm package now declares optional dependencies on
+  platform-specific embedded compiler packages.
+
+## 1.54.4
+
+* Improve error messages when passing incorrect units that are also
+  out-of-bounds to various color functions.
+
+## 1.54.3
+
+* Release a native ARM64 executable for Mac OS.
+
+## 1.54.2
+
+* No user-visible changes.
+
+## 1.54.1
+
+* When unifying selectors for `@extend` and `selector.unify()`, ensure that
+  `:root`, `:scope`, `:host`, and `:host-context` only appear at the beginning
+  of complex selectors.
+
+## 1.54.0
+
+* Deprecate selectors with leading or trailing combinators, or with multiple
+  combinators in a row. If they're included in style rules after nesting is
+  resolved, Sass will now produce a deprecation warning and, in most cases, omit
+  the selector. Leading and trailing combinators can still be freely used for
+  nesting purposes.
+
+  See https://sass-lang.com/d/bogus-combinators for more details.
+
+* Add partial support for new media query syntax from Media Queries Level 4. The
+  only exception are logical operations nested within parentheses, as these were
+  previously interpreted differently as SassScript expressions.
+
+  A parenthesized media condition that begins with `not` or an opening
+  parenthesis now produces a deprecation warning. In a future release, these
+  will be interpreted as plain CSS instead.
+
+* Deprecate passing non-`deg` units to `color.hwb()`'s `$hue` argument.
+
+* Fix a number of bugs when determining whether selectors with pseudo-elements
+  are superselectors.
+
+* Treat `*` as a superselector of all selectors.
+
+### Dart API
+
+* Add a top-level `fakeFromImport()` function for testing custom importers
+  that use `AsyncImporter.fromImport`.
+
+### JS API
+
+* Add a `charset` option that controls whether or not Sass emits a
+  `@charset`/BOM for non-ASCII stylesheets.
+
+* Fix Sass npm package types for TS 4.7+ Node16 and NodeNext module resolution.
+
+## 1.53.0
+
+* Add support for calling `var()` with an empty second argument, such as
+  `var(--side, )`.
+
+### JS API
+
+* Fix a bug where `meta.load-css()` would sometimes resolve relative URLs
+  incorrectly when called from a mixin using the legacy JS API.
+
+### Embedded Sass
+
+* Respect npm's proxy settings when downloading the embedded Sass compiler.
+
+## 1.52.3
+
+* Fix crash when trailing loud comments (`/* ... */`) appear twice in a row
+  across two different imports which themselves imported the same file each.
+
+## 1.52.2
+
+* Preserve location of trailing loud comments (`/* ... */`) instead of pushing
+  the comment to the next line.
+
+## 1.52.1
+
+### Command Line Interface
+
+* Fix a bug where `--watch` mode would close immediately in TTY mode. This was
+  caused by our change to close `--watch` when stdin was closed *outside of* TTY
+  mode, which has been reverted for now while we work on a fix.
+
+## 1.52.0
+
+* Add support for arbitrary modifiers at the end of plain CSS imports, in
+  addition to the existing `supports()` and media queries. Sass now allows any
+  sequence of identifiers of functions after the URL of an import for forwards
+  compatibility with future additions to the CSS spec.
+
+* Fix an issue where source locations tracked through variable references could
+  potentially become incorrect.
+
+* Fix a bug where a loud comment in the source can break the source map when
+  embedding the sources, when using the command-line interface or the legacy JS
+  API.
+
+### JS API
+
+* `SassNumber.assertUnit()` and `SassNumber.assertNoUnits()` now correctly
+  return the number called on when it passes the assertion.
+
+## 1.51.0
+
+* **Potentially breaking change**: Change the order of maps returned by
+  `map.deep-merge()` to match those returned by `map.merge()`. All keys that
+  appeared in the first map will now be listed first in the same order they
+  appeared in that map, followed by any new keys added from the second map.
+
+* Improve the string output of some AST nodes in error messages.
+
+## 1.50.1
+
+### Embedded Sass
+
+* The JS embedded host and the embedded compiler will now properly avoid
+  resolving imports relative to the current working directory unless `'.'` is
+  passed as a load path.
+
+* Fix a bug in the JS embedded host's implementation of the legacy JS API where
+  imports that began with `/` could crash on Windows.
+
+## 1.50.0
+
+* `@extend` now treats [`:where()`] the same as `:is()`.
+
+[`:where()`]: https://developer.mozilla.org/en-US/docs/Web/CSS/:where
+
+### Command Line Interface
+
+* Closing the standard input stream will now cause the `--watch` command to stop
+  running.
+
+### Embedded Sass
+
+* Fix a bug where the JS embedded host crashed when invoking a legacy importer
+  after resolving a relative filesystem import.
+
+* Improve error messages when returning non-`Object` values from legacy
+  importers.
+
+## 1.49.11
+
+* Add support for 64-bit ARM releases on Linux.
+
+### Embedded Sass
+
+* The embedded compiler now correctly sets the `id` field for all
+  `OutboundMessage`s.
+
+## 1.49.10
+
+* Quiet deps mode now silences compiler warnings in mixins and functions that
+  are defined in dependencies even if they're invoked from application
+  stylesheets.
+
+* In expanded mode, Sass will now emit colors using `rgb()`, `rbga()`, `hsl()`,
+  and `hsla()` function notation if they were defined using the corresponding
+  notation. As per our browser support policy, this change was only done once
+  95% of browsers were confirmed to support this output format, and so is not
+  considered a breaking change.
+
+  Note that this output format is intended for human readability and not for
+  interoperability with other tools. As always, Sass targets the CSS
+  specification, and any tool that consumes Sass's output should parse all
+  colors that are supported by the CSS spec.
+
+* Fix a bug in which a color written using the four- or eight-digit hex format
+  could be emitted as a hex color rather than a format with higher browser
+  compatibility.
+
+* Calculations are no longer simplified within supports declarations
+
+## 1.49.9
+
+### Embedded Sass
+
+* Fixed a bug where the legacy API could crash when passed an empty importer
+  list.
+
+## 1.49.8
+
+* Fixed a bug where some plain CSS imports would not be emitted.
+
+### JS API
+
+* Fix a bug where inspecting the Sass module in the Node.js console crashed on
+  Node 17.
+
+### Embedded Sass
+
+* Fix a bug where source map URLs were incorrectly generated when passing
+  importers to the legacy API.
+
+## 1.49.7
+
+### Embedded Sass
+
+* First stable release the `sass-embedded` npm package that contains the Node.js
+  Embedded Host.
+
+* First stable release of the `sass_embedded` pub package that contains the
+  Embedded Dart Sass compiler.
+
+## 1.49.6
+
+* No user-visible changes.
+
+## 1.49.5
+
+* No user-visible changes.
+
+## 1.49.4
+
+* No user-visible changes.
+
+## 1.49.3
+
+* No user-visible changes.
+
+## 1.49.2
+
+* No user-visible changes.
+
+## 1.49.1
+
+* Stop supporting non-LTS Node.js versions.
+
+## 1.49.0
+
+* Fix a bug in `string.insert` with certain negative indices.
+
+### JS API
+
+* Add support for the `sourceMapIncludeSources` option in the new JS API.
+
+#### TypeScript Declarations
+
+* Fix a bug where `LegacyPluginThis.options.linefeed` was typed to return
+  abbreviations when it actually returned literal linefeed characters.
+
+## 1.48.0
+
+### JS API
+
+* **Potentially breaking bug fix:** Match the specification of the new JS API by
+  setting `LegacyResult.map` to `undefined` rather than `null`.
+
+#### TypeScript Declarations
+
+* Add a declaration for the `NULL` constant.
+
+## 1.47.0
+
+### JS API
+
+#### TypeScript Declarations
+
+* Add declarations for the `TRUE` and `FALSE` constants.
+
+## 1.46.0
+
+### JS API
+
+* **Potentially breaking bug fix:** Match the specification of the new JS API by
+  passing `undefined` rather than `null` to `Logger.warn()` for an unset `span`.
+
+#### TypeScript Declarations
+
+* Add a declaration for the `LegacyPluginThis.options.context` field.
+
+* Update the definition of `LegacyAsyncFunction` to include explicit definitions
+  with zero through six arguments before the `done` parameter. This makes it
+  possible for TypeScript users to pass in callbacks that take a specific number
+  of arguments, rather than having to declare a callback that takes an arbitrary
+  number.
+
+* Add a declaration for `types.Error`, a legacy API class that can be returned
+  by asynchronous functions to signal asynchronous errors.
+
+* Add a `LegacyAsyncFunctionDone` type for the `done` callback that's passed to
+  `LegacyAsyncFunction`.
+
+## 1.45.2
+
+### JS API
+
+* **Potentially breaking bug fix:** Change the default value of the `separator`
+  parameter for `new SassArgumentList()` to `','` rather than `null`. This
+  matches the API specification.
+
+## 1.45.1
+
+* **Potentially breaking bug fix:** Properly parse custom properties in
+  `@supports` conditions. Note that this means that SassScript expressions on
+  the right-hand side of custom property `@supports` queries now need to be
+  interpolated, as per https://sass-lang.com/d/css-vars.
+
+* **Potentially breaking bug fix:** Fix a bug where `inspect()` was not
+  properly printing nested, empty, bracketed lists.
+
+## 1.45.0
+
+### JS API
+
+This release includes an entirely new JavaScript API, designed to be more
+idiomatic, performant, and usable. The old API will continue to be supported
+until Dart Sass 2.0.0, but it is now considered deprecated and should be avoided
+for new code.
+
+The new API includes:
+
+* `compile()` and `compileAsync()` functions that take Sass file paths and
+  return the result of compiling them to CSS. The async function returns a
+  `Promise` rather than using a callback-based API.
+
+* `compileString()` and `compileStringAsync()` functions that take a string of
+  Sass source and compiles it to CSS. As above, the async function returns a
+  `Promise`.
+
+* A new importer API that more closely matches the Sass specification's logic
+  for resolving loads. This makes it much easier for Sass to cache information
+  across `@import` and `@use` rules, which substantially improves performance
+  for applications that rely heavily on repeated `@import`s.
+
+* A new custom function API, including much more usable JS representations of
+  Sass value types complete with type-assertion functions, easy map and list
+  lookups, and compatibility with the [`immutable`] package. **Unlike in the
+  legacy API,** function callbacks now take one argument which contains an array
+  of Sass values (rather than taking a separate JS argument for each Sass
+  argument).
+
+[`immutable`]: https://immutable-js.com/
+
+For full documentation of this API, please see [the Sass website][js-api].
+
+[js-api]: https://sass-lang.com/documentation/js-api
+
+This release also adds TypeScript type definitions.
+
+## 1.44.0
+
+* Suggest `calc()` as an alternative in `/`-as-division deprecation messages.
+
+### Dart API
+
+* Add `SassNumber.convert()` and `SassNumber.convertValue()`. These work like
+  `SassNumber.coerce()` and `SassNumber.coerceValue()`, except they don't treat
+  unitless numbers as universally compatible.
+
+* Fix a bug where `SassNumber.coerceToMatch()` and
+  `SassNumber.coerceValueToMatch()` wouldn't coerce single-unit numbers to
+  match unitless numbers.
+
+## 1.43.5
+
+* Fix a bug where calculations with different operators were incorrectly
+  considered equal.
+
+* Properly parse attribute selectors with empty namespaces.
+
+### JS API
+
+* Print more detailed JS stack traces. This is mostly useful for the Sass team's
+  own debugging purposes.
+
+## 1.43.4
+
+### JS API
+
+* Fix a bug where the `logger` option was ignored for the `render()` function.
+
+## 1.43.3
+
+* Improve performance.
+
+## 1.43.2
+
+* Improve the error message when the default namespace of a `@use` rule is not
+  a valid identifier.
+
+## 1.43.1
+
+* No user-visible changes.
+
+## 1.43.0
+
+### JS API
+
+* Add support for the `logger` option. This takes an object that can define
+  `warn` or `debug` methods to add custom handling for messages emitted by the
+  Sass compiler. See [the JS API docs] for details.
+
+  [the JS API docs]: https://sass-lang.com/documentation/js-api/interfaces/Logger
+
+* Add a `Logger.silent` object that can be passed to the `logger` option to
+  silence all messages from the Sass compiler.
+
+## 1.42.1
+
+* Fix a bug where Sass variables and function calls in calculations weren't
+  being resolved correctly if there was a parenthesized interpolation elsewhere
+  in the file.
+
+## 1.42.0
+
+* `min()` and `max()` expressions are once again parsed as calculations as long
+  as they contain only syntax that's allowed in calculation expressions. To
+  avoid the backwards-compatibility issues that were present in 1.40.0, they now
+  allow unitless numbers to be mixed with numbers with units just like the
+  global `min()` and `max()` functions. Similarly, `+` and `-` operations within
+  `min()` and `max()` functions allow unitless numbers to be mixed with numbers
+  with units.
+
+## 1.41.1
+
+* Preserve parentheses around `var()` functions in calculations, because they
+  could potentially be replaced with sub-expressions that might need to be
+  parenthesized.
+
+## 1.41.0
+
+* Calculation values can now be combined with strings using the `+` operator.
+  This was an error in 1.40.0, but this broke stylesheets that were relying on
+  `$value + ""` expressions to generically convert values to strings. (Note that
+  the Sass team recommends the use of `"#{$value}"` or `inspect($value)` for
+  that use-case.)
+
+* The `selector.unify()` function now correctly returns `null` when one selector
+  is a `:host` or `:host-context` and the other is a selector that's guaranteed
+  to be within the current shadow DOM. The `@extend` logic has been updated
+  accordingly as well.
+
+* Fix a bug where extra whitespace in `min()`, `max()`, `clamp()`, and `calc()`
+  expressions could cause bogus parse errors.
+
+* Fix a bug where the right-hand operand of a `-` in a calculation could
+  incorrectly be stripped of parentheses.
+
+### Dart API
+
+* `SassCalculation.plus()` now allows `SassString` arguments.
+
+## 1.40.1
+
+* **Potentially breaking bug fix:** `min()` and `max()` expressions outside of
+  calculations now behave the same way they did in 1.39.2, returning unquoted
+  strings if they contain no Sass-specific features and calling the global
+  `min()` and `max()` functions otherwise. Within calculations, they continue to
+  behave how they did in 1.40.0.
+
+  This fixes an unintended breaking change added in 1.40.0, wherein passing a
+  unitless number and a number without units to `min()` or `max()` now produces
+  an error. Since this breakage affects a major Sass library, we're temporarily
+  reverting support for `min()` and `max()` calculations while we work on
+  designing a longer-term fix.
+
+## 1.40.0
+
+* Add support for first-class `calc()` expressions (as well as `clamp()` and
+  plain-CSS `min()` and `max()`). This means:
+
+  * `calc()` expressions will be parsed more thoroughly, and errors will be
+    highlighted where they weren't before. **This may break your stylesheets,**
+    but only if they were already producing broken CSS.
+
+  * `calc()` expressions will be simplified where possible, and may even return
+    numbers if they can be simplified away entirely.
+
+  * `calc()` expressions that can't be simplified to numbers return a new data
+    type known as "calculations".
+
+  * Sass variables and functions can now be used in `calc()` expressions.
+
+  * New functions `meta.calc-name()` and `meta.calc-args()` can now inspect
+    calculations.
+
+### Dart API
+
+* Add a new value type, `SassCalculation`, that represents calculations.
+
+* Add new `CalculationOperation`, `CalculationOperator`, and
+  `CalculationInterpolation` types to represent types of arguments that may
+  exist as part of a calculation.
+
+* Add a new `Value.assertCalculation()` method.
+
+* Add a new `Number.hasCompatibleUnits()` method.
+
+## 1.39.2
+
+* Fix a bug where configuring with `@use ... with` would throw an error when
+  that variable was defined in a module that also contained `@forward ... with`.
+
+## 1.39.1
+
+* Partial fix for a bug where `@at-root` does not work properly in nested
+  imports that contain `@use` rules. If the only `@use` rules in the nested
+  import are for built-in modules, `@at-root` should now work properly.
+
+## 1.39.0
+
+### JS API
+
+* Add a `charset` option that controls whether or not Sass emits a
+  `@charset`/BOM for non-ASCII stylesheets.
+
+## 1.38.2
+
+* No user-visible changes
+
+## 1.38.1
+
+* No user-visible changes
+
+## 1.38.0
+
+* In expanded mode, emit characters in Unicode private-use areas as escape
+  sequences rather than literal characters.
+
+* Fix a bug where quotes would be omitted for an attribute selector whose value
+  was a single backslash.
+
+* Properly consider numbers that begin with `.` as "plain CSS" for the purposes
+  of parsing plain-CSS `min()` and `max()` functions.
+
+* Allow `if` to be used as an unquoted string.
+
+* Properly parse backslash escapes within `url()` expressions.
+
+* Fix a couple bugs where `@extend`s could be marked as unsatisfied when
+  multiple identical `@extend`s extended selectors across `@use` rules.
+
+### Command Line Interface
+
+* Strip CRLF newlines from snippets of the original stylesheet that are included
+  in the output when an error occurs.
+
+### JS API
+
+* Don't crash when a Windows path is returned by a custom Node importer at the
+  same time as file contents.
+
+* Don't crash when an error occurs in a stylesheet loaded via a custom importer
+  with a custom URL scheme.
+
+### Dart API
+
+* Add a `SassArgumentList.keywordsWithoutMarking` getter to access the keyword
+  arguments of an argument list without marking them accessed.
+
+## 1.37.5
+
+* No user-visible changes.
+
+## 1.37.4
+
+* No user-visible changes.
+
+## 1.37.3
+
+* No user-visible changes.
+
+## 1.37.2
+
+* No user-visible changes.
+
+## 1.37.1
+
+* No user-visible changes.
+
+## 1.37.0
+
+### Dart API
+
+* **Potentially breaking bug fix:** `SassNumber.asSlash`,
+  `SassNumber.withSlash()`, and `SassNumber.withoutSlash()` have been marked as
+  `@internal`. They were never intended to be used outside the `sass` package.
+
+* **Potentially breaking bug fix:** `SassException` has been marked as `@sealed`
+  to formally indicate that it's not intended to be extended outside of the
+  `sass` package.
+
+* Add a `Value.withListContents()` method that returns a new Sass list with the
+  same list separator and brackets as the current value, interpreted as a list.
+
+## 1.36.0
+
+### Dart API
+
+* Added `compileToResult()`, `compileStringToResult()`,
+  `compileToResultAsync()`, and `compileStringToResultAsync()` methods. These
+  are intended to replace the existing `compile*()` methods, which are now
+  deprecated. Rather than returning a simple string, these return a
+  `CompileResult` object, which will allow us to add additional information
+  about the compilation without having to introduce further deprecations.
+
+  * Instead of passing a `sourceMaps` callback to `compile*()`, pass
+    `sourceMaps: true` to `compile*ToResult()` and access
+    `CompileResult.sourceMap`.
+
+  * The `CompileResult` object exposes a `loadedUrls` object which lists the
+    canonical URLs accessed during a compilation. This information was
+    previously unavailable except through the JS API.
+
+## 1.35.2
+
+* **Potentially breaking bug fix**: Properly throw an error for Unicode ranges
+  that have too many `?`s after hexadecimal digits, such as `U+12345??`.
+
+* **Potentially breaking bug fix:** Fixed a bug where certain local variable
+  declarations nested within multiple `@if` statements would incorrectly
+  override a global variable. It's unlikely that any real stylesheets were
+  relying on this bug, but if so they can simply add `!global` to the variable
+  declaration to preserve the old behavior.
+
+* **Potentially breaking bug fix:** Fix a bug where imports of root-relative
+  URLs (those that begin with `/`) in `@import` rules would be passed to
+  both Dart and JS importers as `file:` URLs.
+
+* Properly support selector lists for the `$extendee` argument to
+  `selector.extend()` and `selector.replace()`.
+
+* Fix an edge case where `@extend` wouldn't affect a selector within a
+  pseudo-selector such as `:is()` that itself extended other selectors.
+
+* Fix a race condition where `meta.load-css()` could trigger an internal error
+  when running in asynchronous mode.
+
+### Dart API
+
+* Use the `@internal` annotation to indicate which `Value` APIs are available
+  for public use.
+
+## 1.35.1
+
+* Fix a bug where the quiet dependency flag didn't silence warnings in some
+  stylesheets loaded using `@import`.
+
+## 1.35.0
+
+* Fix a couple bugs that could prevent some members from being found in certain
+  files that use a mix of imports and the module system.
+
+* Fix incorrect recommendation for migrating division expressions that reference
+  namespaced variables.
+
+### JS API
+
+* Add a `quietDeps` option which silences compiler warnings from stylesheets
+  loaded through importers and load paths.
+
+* Add a `verbose` option which causes the compiler to emit all deprecation
+  warnings, not just 5 per feature.
+
+## 1.34.1
+
+* Fix a bug where `--update` would always compile any file that depends on a
+  built-in module.
+
+* Fix the URL for the `@-moz-document` deprecation message.
+
+* Fix a bug with `@for` loops nested inside property declarations.
+
+## 1.34.0
+
+* Don't emit the same warning in the same location multiple times.
+
+* Cap deprecation warnings at 5 per feature by default.
+
+### Command Line Interface
+
+* Add a `--quiet-deps` flag which silences compiler warnings from stylesheets
+  loaded through `--load-path`s.
+
+* Add a `--verbose` flag which causes the compiler to emit all deprecation
+  warnings, not just 5 per feature.
+
+### Dart API
+
+* Add a `quietDeps` argument to `compile()`, `compileString()`,
+  `compileAsync()`, and `compileStringAsync()` which silences compiler warnings
+  from stylesheets loaded through importers, load paths, and `package:` URLs.
+
+* Add a `verbose` argument to `compile()`, `compileString()`, `compileAsync()`,
+  and `compileStringAsync()` which causes the compiler to emit all deprecation
+  warnings, not just 5 per feature.
+
+## 1.33.0
+
+* Deprecate the use of `/` for division. The new `math.div()` function should be
+  used instead. See [this page][] for details.
+
+[this page]: https://sass-lang.com/documentation/breaking-changes/slash-div
+
+* Add a `list.slash()` function that returns a slash-separated list.
+
+* **Potentially breaking bug fix:** The heuristics around when potentially
+  slash-separated numbers are converted to slash-free numbers—for example, when
+  `1/2` will be printed as `0.5` rather than `1/2`—have been slightly expanded.
+  Previously, a number would be made slash-free if it was passed as an argument
+  to a *user-defined function*, but not to a *built-in function*. Now it will be
+  made slash-free in both cases. This is a behavioral change, but it's unlikely
+  to affect any real-world stylesheets.
+
+* [`:is()`][] now behaves identically to `:matches()`.
+
+[`:is()`]: https://developer.mozilla.org/en-US/docs/Web/CSS/:is
+
+* Fix a bug where non-integer numbers that were very close to integer
+  values would be incorrectly formatted in CSS.
+
+* Fix a bug where very small number and very large negative numbers would be
+  incorrectly formatted in CSS.
+
+### JS API
+
+* The `this` context for importers now has a `fromImport` field, which is `true`
+  if the importer is being invoked from an `@import` and `false` otherwise.
+  Importers should only use this to determine whether to load [import-only
+  files].
+
+[import-only files]: https://sass-lang.com/documentation/at-rules/import#import-only-files
+
+### Dart API
+
+* Add an `Importer.fromImport` getter, which is `true` if the current
+  `Importer.canonicalize()` call comes from an `@import` rule and `false`
+  otherwise. Importers should only use this to determine whether to load
+  [import-only files].
+
+## 1.32.13
+
+* **Potentially breaking bug fix:** Null values in `@use` and `@forward`
+  configurations no longer override the `!default` variable, matching the
+  behavior of the equivalent code using `@import`.
+
+* Use the proper parameter names in error messages about `string.slice`
+
+## 1.32.12
+
+* Fix a bug that disallowed more than one module from extending the same
+  selector from a module if that selector itself extended a selector from
+  another upstream module.
+
+## 1.32.11
+
+* Fix a bug where bogus indented syntax errors were reported for lines that
+  contained only whitespace.
+
+## 1.32.10
+
+* No user-visible changes.
+
+## 1.32.9
+
+* Fix a typo in a deprecation warning.
+
+### JavaScript API
+
+* Drop support for Chokidar 2.x. This version was incompatible with Node 14, but
+  due to shortcomings in npm's version resolver sometimes still ended up
+  installed anyway. Only declaring support for 3.0.0 should ensure compatibility
+  going forward.
+
+### Dart API
+
+* Allow the null safety release of args and watcher.
+
+### Command Line Interface
+
+* Add a `-w` shorthand for the `--watch` flag.
+
+## 1.32.8
+
+* Update chokidar version for Node API tests.
+
+### JavaScript API
+
+* Allow a custom function to access the `render()` options object within its
+  local context, as `this.options`.
+
+## 1.32.7
+
+* Allow the null safety release of stream_transform.
+
+* Allow `@forward...with` to take arguments that have a `!default` flag without
+  a trailing comma.
+
+* Improve the performance of unitless and single-unit numbers.
+
+## 1.32.6
+
+### Node JS API
+
+* Fix Electron support when `nodeIntegration` is disabled.
+
+### Dart API
+
+* All range checks for `SassColor` constructors now throw `RangeError`s with
+  `start` and `end` set.
+
+## 1.32.5
+
+* **Potentially breaking bug fix:** When using `@for` with numbers that have
+  units, the iteration variable now matches the unit of the initial number. This
+  matches the behavior of Ruby Sass and LibSass.
+
+### Node JS API
+
+* Fix a few infrequent errors when calling `render()` with `fiber` multiple
+  times simultaneously.
+
+* Avoid possible mangled error messages when custom functions or importers throw
+  unexpected exceptions.
+
+* Fix Electron support when `nodeIntegration` is disabled.
+
+## 1.32.4
+
+* No user-visible changes.
+
+## 1.32.3
+
+* Optimize `==` for numbers that have different units.
+
+## 1.32.2
+
+* Print the actual number that was received in unit deprecation warnings for
+  color functions.
+
+## 1.32.1
+
+* Don't emit permissions errors on Windows and OS X when trying to determine the
+  real case of path names.
+
+## 1.32.0
+
+* Deprecate passing non-`%` numbers as lightness and saturation to `hsl()`,
+  `hsla()`, `color.adjust()`, and `color.change()`. This matches the CSS
+  specification, which also requires `%` for all lightness and saturation
+  parameters. See [the Sass website][color-units] for more details.
+
+* Deprecate passing numbers with units other than `deg` as the hue to `hsl()`,
+  `hsla()`, `adjust-hue()`, `color.adjust()`, and `color.change()`. Unitless
+  numbers *are* still allowed here, since they're allowed by CSS. See [the Sass
+  website][color-units] for more details.
+
+* Improve error messages about incompatible units.
+
+* Properly mark some warnings emitted by `sass:color` functions as deprecation
+  warnings.
+
+### Dart API
+
+* Rename `SassNumber.valueInUnits()` to `SassNumber.coerceValue()`. The old name
+  remains, but is now deprecated.
+
+* Rename `SassNumber.coerceValueToUnit()`, a shorthand for
+  `SassNumber.coerceValue()` that takes a single numerator unit.
+
+* Add `SassNumber.coerceToMatch()` and `SassNumber.coerceValueToMatch()`, which
+  work like `SassNumber.coerce()` and `SassNumber.coerceValue()` but take a
+  `SassNumber` whose units should be matched rather than taking the units
+  explicitly. These generate better error messages than `SassNumber.coerce()`
+  and `SassNumber.coerceValue()`.
+
+* Add `SassNumber.convertToMatch()` and `SassNumber.convertValueToMatch()`,
+  which work like `SassNumber.coerceToMatch()` and
+  `SassNumber.coerceValueToMatch()` except they throw exceptions when converting
+  unitless values to or from units.
+
+* Add `SassNumber.compatibleWithUnit()`, which returns whether the number can be
+  coerced to a single numerator unit.
+
+## 1.31.0
+
+* Add support for parsing `clamp()` as a special math function, the same way
+  `calc()` is parsed.
+
+* Properly load files in case-sensitive Windows directories with upper-case
+  names.
+
+## 1.30.0
+
+* Fix a bug where `@at-root (without: all)` wouldn't properly remove a
+  `@keyframes` context when parsing selectors.
+
+### Node JS API
+
+* The generated `main()` function in `sass.js` now returns a `Promise` that
+  completes when the executable is finished running.
+
+### Dart API
+
+* Fix a bug that prevented importers from returning null when loading from a
+  URL that they had already canonicalized.
+
+## 1.29.0
+
+* Support a broader syntax for `@supports` conditions, based on the latest
+  [Editor's Draft of CSS Conditional Rules 3]. Almost all syntax will be allowed
+  (with interpolation) in the conditions' parentheses, as well as function
+  syntax such as `@supports selector(...)`.
+
+[Editor's Draft of CSS Conditional Rules 3]: https://drafts.csswg.org/css-conditional-3/#at-supports
+
+## 1.28.0
+
+* Add a [`color.hwb()`] function to `sass:color` that can express colors in [HWB] format.
+
+[`color.hwb()`]: https://sass-lang.com/documentation/modules/color#hwb
+[HWB]: https://en.wikipedia.org/wiki/HWB_color_model
+
+* Add [`color.whiteness()`] and [`color.blackness()`] functions to `sass:color`
+  to get a color's [HWB] whiteness and blackness components.
+
+[`color.whiteness()`]: https://sass-lang.com/documentation/modules/color#whiteness
+[`color.blackness()`]: https://sass-lang.com/documentation/modules/color#blackness
+
+* Add `$whiteness` and `$blackness` parameters to [`color.adjust()`],
+  [`color.change()`], and [`color.scale()`] to modify a color's [HWB] whiteness
+  and blackness components.
+
+[`color.adjust()`]: https://sass-lang.com/documentation/modules/color#adjust
+[`color.change()`]: https://sass-lang.com/documentation/modules/color#change
+[`color.scale()`]: https://sass-lang.com/documentation/modules/color#scale
+
+### Dart API
+
+* Add [HWB] support to the `SassColor` class, including a `SassColor.hwb()`
+  constructor, `whiteness` and `blackness` getters, and a `changeHwb()` method.
+
+[HWB]: https://en.wikipedia.org/wiki/HWB_color_model
+
+## 1.27.2
+
+* No user-visible changes.
+
+## 1.27.1
+
+* **Potentially breaking bug fix:** `meta.load-css()` now correctly uses the
+  name `$url` for its first argument, rather than `$module`.
+
+* Don't crash when using `Infinity` or `NaN` as a key in a map.
+
+* Emit a proper parse error for a `=` with no right-hand side in a function.
+
+* Avoid going exponential on certain recursive `@extend` edge cases.
+
+## 1.27.0
+
+* Adds an overload to `map.merge()` that supports merging a nested map.
+
+  `map.merge($map1, $keys..., $map2)`: The `$keys` form a path to the nested map
+  in `$map1`, into which `$map2` gets merged.
+
+  See [the Sass documentation][map-merge] for more details.
+
+  [map-merge]: https://sass-lang.com/documentation/modules/map#merge
+
+* Adds an overloaded `map.set()` function.
+
+  `map.set($map, $key, $value)`: Adds to or updates `$map` with the specified
+  `$key` and `$value`.
+
+  `map.set($map, $keys..., $value)`: Adds to or updates a map that is nested
+  within `$map`. The `$keys` form a path to the nested map in `$map`, into
+  which `$value` is inserted.
+
+  See [the Sass documentation][map-set] for more details.
+
+  [map-set]: https://sass-lang.com/documentation/modules/map#set
+
+* Add support for nested maps to `map.get()`.
+  For example, `map.get((a: (b: (c: d))), a, b, c)` would return `d`.
+  See [the documentation][map-get] for more details.
+
+  [map-get]: https://sass-lang.com/documentation/modules/map#get
+
+* Add support for nested maps in `map.has-key`.
+  For example, `map.has-key((a: (b: (c: d))), a, b, c)` would return true.
+  See [the documentation][map-has-key] for more details.
+
+  [map-has-key]: https://sass-lang.com/documentation/modules/map#has-key
+
+* Add a `map.deep-merge()` function. This works like `map.merge()`, except that
+  nested map values are *also* recursively merged. For example:
+
+  ```
+  map.deep-merge(
+    (color: (primary: red, secondary: blue),
+    (color: (secondary: teal)
+  ) // => (color: (primary: red, secondary: teal))
+  ```
+
+  See [the Sass documentation][map-deep-merge] for more details.
+
+  [map-deep-merge]: https://sass-lang.com/documentation/modules/map#deep-merge
+
+* Add a `map.deep-remove()` function. This allows you to remove keys from
+  nested maps by passing multiple keys. For example:
+
+  ```
+  map.deep-remove(
+    (color: (primary: red, secondary: blue)),
+    color, primary
+  ) // => (color: (secondary: blue))
+  ```
+
+  See [the Sass documentation][map-deep-remove] for more details.
+
+  [map-deep-remove]: https://sass-lang.com/documentation/modules/map#deep-remove
+
+* Fix a bug where custom property values in plain CSS were being parsed as
+  normal property values.
+
+### Dart API
+
+* Add a `Value.tryMap()` function which returns the `Value` as a `SassMap` if
+  it's a valid map, or `null` otherwise. This allows function authors to safely
+  retrieve maps even if they're internally stored as empty lists, without having
+  to catch exceptions from `Value.assertMap()`.
+
+## 1.26.12
+
+* Fix a bug where nesting properties beneath a Sass-syntax custom property
+  (written as `#{--foo}: ...`) would crash.
+
+## 1.26.11
+
+* **Potentially breaking bug fix:** `selector.nest()` now throws an error
+  if the first arguments contains the parent selector `&`.
+
+* Fixes a parsing bug with inline comments in selectors.
+
+* Improve some error messages for edge-case parse failures.
+
+* Throw a proper error when the same built-in module is `@use`d twice.
+
+* Don't crash when writing `Infinity` in JS mode.
+
+* Produce a better error message for positional arguments following named
+  arguments.
+
+## 1.26.10
+
+* Fixes a bug where two adjacent combinators could cause an error.
+
+## 1.26.9
+
+* Use an updated version of `node_preamble` when compiling to JS.
+
+## 1.26.8
+
+* Fixes an error when emitting source maps to stdout.
+
+## 1.26.7
+
+* No user-visible changes.
+
+## 1.26.6
+
+* Fix a bug where escape sequences were improperly recognized in `@else` rules.
+
+### JavaScript API
+
+* Add `sass.NULL`, `sass.TRUE`, and `sass.FALSE` constants to match Node Sass's
+  API.
+
+* If a custom Node importer returns both `file` and `contents`, don't attempt to
+  read the `file`. Instead, use the `contents` provided by the importer, with
+  `file` as the canonical url.
+
+## 1.26.5
+
+* No user-visible changes.
+
+## 1.26.4
+
+* Be more memory-efficient when handling `@forward`s through `@import`s.
+
+## 1.26.3
+
+* Fix a bug where `--watch` mode could go into an infinite loop compiling CSS
+  files to themselves.
+
+## 1.26.2
+
+* More aggressively eliminate redundant selectors in the `selector.extend()` and
+  `selector.replace()` functions.
+
+## 1.26.1
+
+### Command Line Interface
+
+* Fix a longstanding bug where `--watch` mode could enter into a state where
+  recompilation would not occur after a syntax error was introduced into a
+  dependency and then fixed.
+
+## 1.26.0
+
+* **Potentially breaking bug fix:** `@use` rules whose URLs' basenames begin
+  with `_` now correctly exclude that `_` from the rules' namespaces.
+
+* Fix a bug where imported forwarded members weren't visible in mixins and
+  functions that were defined before the `@import`.
+
+* Don't throw errors if the exact same member is loaded or forwarded from
+  multiple modules at the same time.
+
+## 1.25.2
+
+* Fix a bug where, under extremely rare circumstances, a valid variable could
+  become unassigned.
+
+## 1.25.0
+
+* Add functions to the built-in "sass:math" module.
+
+  * `clamp($min, $number, $max)`. Clamps `$number` in between `$min` and `$max`.
+
+  * `hypot($numbers...)`. Given *n* numbers, outputs the length of the
+    *n*-dimensional vector that has components equal to each of the inputs.
+
+  * Exponential. All inputs must be unitless.
+    * `log($number)` or `log($number, $base)`. If no base is provided, performs
+       a natural log.
+    * `pow($base, $exponent)`
+    * `sqrt($number)`
+
+  * Trigonometric. The input must be an angle. If no unit is given, the input is
+    assumed to be in `rad`.
+    * `cos($number)`
+    * `sin($number)`
+    * `tan($number)`
+
+  * Inverse trigonometric. The output is in `deg`.
+    * `acos($number)`. Input must be unitless.
+    * `asin($number)`. Input must be unitless.
+    * `atan($number)`. Input must be unitless.
+    * `atan2($y, $x)`. `$y` and `$x` must have compatible units or be unitless.
+
+* Add the variables `$pi` and `$e` to the built-in "sass:math" module.
+
+### JavaScript API
+
+* `constructor.value` fields on value objects now match their Node Sass
+  equivalents.
+
+## 1.24.5
+
+* Highlight contextually-relevant sections of the stylesheet in error messages,
+  rather than only highlighting the section where the error was detected.
+
+## 1.24.4
+
+### JavaScript API
+
+* Fix a bug where source map generation would crash with an absolute source map
+  path and a custom importer that returns string file contents.
+
+## 1.24.3
+
+### Command Line Interface
+
+* Fix a bug where `sass --version` would crash for certain executable
+  distributions.
+
+## 1.24.2
+
+### JavaScript API
+
+* Fix a bug introduced in the previous release that prevented custom importers
+  in Node.js from loading import-only files.
+
+## 1.24.1
+
+* Fix a bug where the wrong file could be loaded when the same URL is used by
+  both a `@use` rule and an `@import` rule.
+
+## 1.24.0
+
+* Add an optional `with` clause to the `@forward` rule. This works like the
+  `@use` rule's `with` clause, except that `@forward ... with` can declare
+  variables as `!default` to allow downstream modules to reconfigure their
+  values.
+
+* Support configuring modules through `@import` rules.
+
+## 1.23.8
+
+* **Potentially breaking bug fix:** Members loaded through a nested `@import`
+  are no longer ever accessible outside that nested context.
+
+* Don't throw an error when importing two modules that both forward members with
+  the same name. The latter name now takes precedence over the former, as per
+  the specification.
+
+### Dart API
+
+* `SassFormatException` now implements `SourceSpanFormatException` (and thus
+  `FormatException`).
+
+## 1.23.7
+
+* No user-visible changes
+
+## 1.23.6
+
+* No user-visible changes.
+
+## 1.23.5
+
+* Support inline comments in the indented syntax.
+
+* When an overloaded function receives the wrong number of arguments, guess
+  which overload the user actually meant to invoke, and display the invalid
+  argument error for that overload.
+
+* When `@error` is used in a function or mixin, print the call site rather than
+  the location of the `@error` itself to better match the behavior of calling a
+  built-in function that throws an error.
+
+## 1.23.4
+
+### Command-Line Interface
+
+* Fix a bug where `--watch` wouldn't watch files referred to by `@forward`
+  rules.
+
+## 1.23.3
+
+* Fix a bug where selectors were being trimmed over-eagerly when `@extend`
+  crossed module boundaries.
+
+## 1.23.2
+
+### Command-Line Interface
+
+* Fix a bug when compiling all Sass files in a directory where a CSS file could
+  be compiled to its own location, creating an infinite loop in `--watch` mode.
+
+* Properly compile CSS entrypoints in directories outside of `--watch` mode.
+
+## 1.23.1
+
+* Fix a bug preventing built-in modules from being loaded within a configured
+  module.
+
+* Fix a bug preventing an unconfigured module from being loaded from within two
+  different configured modules.
+
+* Fix a bug when `meta.load-css()` was used to load some files that included
+  media queries.
+
+* Allow `saturate()` in plain CSS files, since it can be used as a plain CSS
+  filter function.
+
+* Improve the error messages for trying to access functions like `lighten()`
+  from the `sass:color` module.
+
+## 1.23.0
+
+* **Launch the new Sass module system!** This adds:
+
+  * The [`@use` rule][], which loads Sass files as *modules* and makes their
+    members available only in the current file, with automatic namespacing.
+
+    [`@use` rule]: https://sass-lang.com/documentation/at-rules/use
+
+  * The [`@forward` rule][], which makes members of another Sass file available
+    to stylesheets that `@use` the current file.
+
+    [`@forward` rule]: https://sass-lang.com/documentation/at-rules/forward
+
+  * Built-in modules named `sass:color`, `sass:list`, `sass:map`, `sass:math`,
+    `sass:meta`, `sass:selector`, and `sass:string` that provide access to all
+    the built-in Sass functions you know and love, with automatic module
+    namespaces.
+
+  * The [`meta.load-css()` mixin][], which includes the CSS contents of a module
+    loaded from a (potentially dynamic) URL.
+
+    [`meta.load-css()` mixin]: https://sass-lang.com/documentation/modules/meta#load-css
+
+  * The [`meta.module-variables()` function][], which provides access to the
+    variables defined in a given module.
+
+    [`meta.module-variables()` function]: https://sass-lang.com/documentation/modules/meta#module-variables
+
+  * The [`meta.module-functions()` function][], which provides access to the
+    functions defined in a given module.
+
+    [`meta.module-functions()` function]: https://sass-lang.com/documentation/modules/meta#module-functions
+
+  Check out [the Sass blog][migrator blog] for more information on the new
+  module system. You can also use the new [Sass migrator][] to automatically
+  migrate your stylesheets to the new module system!
+
+  [migrator blog]: https://sass-lang.com/blog/the-module-system-is-launched
+  [Sass migrator]: https://sass-lang.com/documentation/cli/migrator
+
+## 1.22.12
+
+* **Potentially breaking bug fix:** character sequences consisting of two or
+  more hyphens followed by a number (such as `--123`), or two or more hyphens on
+  their own (such as `--`), are now parsed as identifiers [in accordance with
+  the CSS spec][ident-token-diagram].
+
+  [ident-token-diagram]: https://drafts.csswg.org/css-syntax-3/#ident-token-diagram
+
+  The sequence `--` was previously parsed as multiple applications of the `-`
+  operator. Since this is unlikely to be used intentionally in practice, we
+  consider this bug fix safe.
+
+### Command-Line Interface
+
+* Fix a bug where changes in `.css` files would be ignored in `--watch` mode.
+
+### JavaScript API
+
+* Allow underscore-separated custom functions to be defined.
+
+* Improve the performance of Node.js compilation involving many `@import`s.
+
+## 1.22.11
+
+* Don't try to load unquoted plain-CSS indented-syntax imports.
+
+* Fix a couple edge cases in `@extend` logic and related selector functions:
+
+  * Recognize `:matches()` and similar pseudo-selectors as superselectors of
+    matching complex selectors.
+
+  * Recognize `::slotted()` as a superselector of other `::slotted()` selectors.
+
+  * Recognize `:current()` with a vendor prefix as a superselector.
+
+## 1.22.10
+
+* Fix a bug in which `get-function()` would fail to find a dash-separated
+  function when passed a function name with underscores.
+
+## 1.22.9
+
+* Include argument names when reporting range errors and selector parse errors.
+
+* Avoid double `Error:` headers when reporting selector parse errors.
+
+* Clarify the error message when the wrong number of positional arguments are
+  passed along with a named argument.
+
+### JavaScript API
+
+* Re-add support for Node Carbon (8.x).
+
+## 1.22.8
+
+### JavaScript API
+
+* Don't crash when running in a directory whose name contains URL-sensitive
+  characters.
+
+* Drop support for Node Carbon (8.x), which doesn't support `url.pathToFileURL`.
+
+## 1.22.7
+
+* Restrict the supported versions of the Dart SDK to `^2.4.0`.
+
+## 1.22.6
+
+* **Potentially breaking bug fix:** The `keywords()` function now converts
+  underscore-separated argument names to hyphen-separated names. This matches
+  LibSass's behavior, but not Ruby Sass's.
+
+* Further improve performance for logic-heavy stylesheets.
+
+* Improve a few error messages.
+
+## 1.22.5
+
+### JavaScript API
+
+* Improve performance for logic-heavy stylesheets.
+
+## 1.22.4
+
+* Fix a bug where at-rules imported from within a style rule would appear within
+  that style rule rather than at the root of the document.
+
+## 1.22.3
+
+* **Potentially breaking bug fix:** The argument name for the `saturate()`
+  function is now `$amount`, to match the name in LibSass and originally in Ruby
+  Sass.
+
+* **Potentially breaking bug fix:** The `invert()` function now properly returns
+  `#808080` when passed `$weight: 50%`. This matches the behavior in LibSass and
+  originally in Ruby Sass, as well as being consistent with other nearby values
+  of `$weight`.
+
+* **Potentially breaking bug fix:** The `invert()` function now throws an error
+  if it's used [as a plain CSS function][plain-CSS invert] *and* the Sass-only
+  `$weight` parameter is passed. This never did anything useful, so it's
+  considered a bug fix rather than a full breaking change.
+
+  [plain-CSS invert]: https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/invert
+
+* **Potentially breaking bug fix**: The `str-insert()` function now properly
+  inserts at the end of the string if the `$index` is `-1`. This matches the
+  behavior in LibSass and originally in Ruby Sass.
+
+* **Potentially breaking bug fix**: An empty map returned by `map-remove()` is
+  now treated as identical to the literal value `()`, rather than being treated
+  as though it had a comma separator. This matches the original behavior in Ruby
+  Sass.
+
+* The `adjust-color()` function no longer throws an error when a large `$alpha`
+  value is combined with HSL adjustments.
+
+* The `alpha()` function now produces clearer error messages when the wrong
+  number of arguments are passed.
+
+* Fix a bug where the `str-slice()` function could produce invalid output when
+  passed a string that contains characters that aren't represented as a single
+  byte in UTF-16.
+
+* Improve the error message for an unknown separator name passed to the `join()`
+  or `append()` functions.
+
+* The `zip()` function no longer deadlocks if passed no arguments.
+
+* The `map-remove()` function can now take a `$key` named argument. This matches
+  the signature in LibSass and originally in Ruby Sass.
+
+## 1.22.2
+
+### JavaScript API
+
+* Avoid re-assigning the `require()` function to make the code statically
+  analyzable by Webpack.
+
+## 1.22.1
+
+### JavaScript API
+
+* Expand the dependency on `chokidar` to allow 3.x.
+
+## 1.22.0
+
+* Produce better stack traces when importing a file that contains a syntax
+  error.
+
+* Make deprecation warnings for `!global` variable declarations that create new
+  variables clearer, especially in the case where the `!global` flag is
+  unnecessary because the variables are at the top level of the stylesheet.
+
+### Dart API
+
+* Add a `Value.realNull` getter, which returns Dart's `null` if the value is
+  Sass's null.
+
+## 1.21.0
+
+### Dart API
+
+* Add a `sass` executable when installing the package through `pub`.
+
+* Add a top-level `warn()` function for custom functions and importers to print
+  warning messages.
+
+## 1.20.3
+
+* No user-visible changes.
+
+## 1.20.2
+
+* Fix a bug where numbers could be written using exponential notation in
+  Node.js.
+
+* Fix a crash that would appear when writing some very large integers to CSS.
+
+### Command-Line Interface
+
+* Improve performance for stand-alone packages on Linux and Mac OS.
+
+### JavaScript API
+
+* Pass imports to custom importers before resolving them using `includePaths` or
+  the `SASS_PATH` environment variable. This matches Node Sass's behavior, so
+  it's considered a bug fix.
+
+## 1.20.1
+
+* No user-visible changes.
+
+## 1.20.0
+
+* Support attribute selector modifiers, such as the `i` in `[title="test" i]`.
+
+### Command-Line Interface
+
+* When compilation fails, Sass will now write the error message to the CSS
+  output as a comment and as the `content` property of a `body::before` rule so
+  it will show up in the browser (unless compiling to standard output). This can
+  be disabled with the `--no-error-css` flag, or forced even when compiling to
+  standard output with the `--error-css` flag.
+
+### Dart API
+
+* Added `SassException.toCssString()`, which returns the contents of a CSS
+  stylesheet describing the error, as above.
+
+## 1.19.0
+
+* Allow `!` in `url()`s without quotes.
+
+### Dart API
+
+* `FilesystemImporter` now doesn't change its effective directory if the working
+  directory changes, even if it's passed a relative argument.
+
+## 1.18.0
+
+* Avoid recursively listing directories when finding the canonical name of a
+  file on case-insensitive filesystems.
+
+* Fix importing files relative to `package:`-imported files.
+
+* Don't claim that "package:" URLs aren't supported when they actually are.
+
+### Command-Line Interface
+
+* Add a `--no-charset` flag. If this flag is set, Sass will never emit a
+  `@charset` declaration or a byte-order mark, even if the CSS file contains
+  non-ASCII characters.
+
+### Dart API
+
+* Add a `charset` option to `compile()`, `compileString()`, `compileAsync()` and
+  `compileStringAsync()`. If this option is set to `false`, Sass will never emit
+  a `@charset` declaration or a byte-order mark, even if the CSS file contains
+  non-ASCII characters.
+
+* Explicitly require that importers' `canonicalize()` methods be able to take
+  paths relative to their outputs as valid inputs. This isn't considered a
+  breaking change because the importer infrastructure already required this in
+  practice.
+
+## 1.17.4
+
+* Consistently parse U+000C FORM FEED, U+000D CARRIAGE RETURN, and sequences of
+  U+000D CARRIAGE RETURN followed by U+000A LINE FEED as individual newlines.
+
+### JavaScript API
+
+* Add a `sass.types.Error` constructor as an alias for `Error`. This makes our
+  custom function API compatible with Node Sass's.
+
+## 1.17.3
+
+* Fix an edge case where slash-separated numbers were written to the stylesheet
+  with a slash even when they're used as part of another arithmetic operation,
+  such as being concatenated with a string.
+
+* Don't put style rules inside empty `@keyframes` selectors.
+
+## 1.17.2
+
+* Deprecate `!global` variable assignments to variables that aren't yet defined.
+  This deprecation message can be avoided by assigning variables to `null` at
+  the top level before globally assigning values to them.
+
+### Dart API
+
+* Explicitly mark classes that were never intended to be subclassed or
+  implemented as "sealed".
+
+## 1.17.1
+
+* Properly quote attribute selector values that start with identifiers but end
+  with a non-identifier character.
+
+## 1.17.0
+
+* Improve error output, particularly for errors that cover multiple lines.
+
+* Improve source locations for some parse errors. Rather than pointing to the
+  next token that wasn't what was expected, they point *after* the previous
+  token. This should generally provide more context for the syntax error.
+
+* Produce a better error message for style rules that are missing the closing
+  `}`.
+
+* Produce a better error message for style rules and property declarations
+  within `@function` rules.
+
+### Command-Line Interface
+
+* Passing a directory on the command line now compiles all Sass source files in
+  the directory to CSS files in the same directory, as though `dir:dir` were
+  passed instead of just `dir`.
+
+* The new error output uses non-ASCII Unicode characters by default. Add a
+  `--no-unicode` flag to disable this.
+
+## 1.16.1
+
+* Fix a performance bug where stylesheet evaluation could take a very long time
+  when many binary operators were used in sequence.
+
+## 1.16.0
+
+* `rgb()` and `hsl()` now treat unquoted strings beginning with `env()`,
+  `min()`, and `max()` as special number strings like `calc()`.
+
+## 1.15.3
+
+* Properly merge `all and` media queries. These queries were previously being
+  merged as though `all` referred to a specific media type, rather than all
+  media types.
+
+* Never remove units from 0 values in compressed mode. This wasn't safe in
+  general, since some properties (such as `line-height`) interpret `0` as a
+  `<number>` rather than a `<length>` which can break CSS transforms. It's
+  better to do this optimization in a dedicated compressor that's aware of CSS
+  property semantics.
+
+* Match Ruby Sass's behavior in some edge-cases involving numbers with many
+  significant digits.
+
+* Emit escaped tab characters in identifiers as `\9` rather than a backslash
+  followed by a literal tab.
+
+### Command-Line Interface
+
+* The source map generated for a stylesheet read from standard input now uses a
+  `data:` URL to include that stylesheet's contents in the source map.
+
+### Node JS API
+
+* `this.includePaths` for a running importer is now a `;`-separated string on
+  Windows, rather than `:`-separated. This matches Node Sass's behavior.
+
+### Dart API
+
+* The URL used in a source map to refer to a stylesheet loaded from an importer
+  is now `ImportResult.sourceMapUrl` as documented.
+
+## 1.15.2
+
+### Node JS API
+
+* When `setValue()` is called on a Sass string object, make it unquoted even if
+  it was quoted originally, to match the behavior of Node Sass.
+
+## 1.15.1
+
+* Always add quotes to attribute selector values that begin with `--`, since IE
+  11 doesn't consider them to be identifiers.
+
+## 1.15.0
+
+* Add support for passing arguments to `@content` blocks. See [the
+  proposal][content-args] for details.
+
+* Add support for the new `rgb()` and `hsl()` syntax introduced in CSS Colors
+  Level 4, such as `rgb(0% 100% 0% / 0.5)`. See [the proposal][color-4-rgb-hsl]
+  for more details.
+
+* Add support for interpolation in at-rule names. See [the
+  proposal][at-rule-interpolation] for details.
+
+* Add paths from the `SASS_PATH` environment variable to the load paths in the
+  command-line interface, Dart API, and JS API. These load paths are checked
+  just after the load paths explicitly passed by the user.
+
+* Allow saturation and lightness values outside of the `0%` to `100%` range in
+  the `hsl()` and `hsla()` functions. They're now clamped to be within that
+  range rather than producing an error if they're outside it.
+
+* Properly compile selectors that end in escaped whitespace.
+
+[content-args]: https://github.com/sass/language/blob/master/accepted/content-args.md
+[color-4-rgb-hsl]: https://github.com/sass/language/blob/master/accepted/color-4-rgb-hsl.md
+[at-rule-interpolation]: https://github.com/sass/language/blob/master/accepted/at-rule-interpolation.md
+
+### JavaScript API
+
+* Always include the error location in error messages.
+
+## 1.14.4
+
+* Properly escape U+0009 CHARACTER TABULATION in unquoted strings.
+
+## 1.14.3
+
+* Treat `:before`, `:after`, `:first-line`, and `:first-letter` as
+  pseudo-elements for the purposes of `@extend`.
+
+* When running in compressed mode, remove spaces around combinators in complex
+  selectors, so a selector like `a > b` is output as `a>b`.
+
+* Properly indicate the source span for errors involving binary operation
+  expressions whose operands are parenthesized.
+
+## 1.14.2
+
+* Fix a bug where loading the same stylesheet from two different import paths
+  could cause its imports to fail to resolve.
+
+* Properly escape U+001F INFORMATION SEPARATOR ONE in unquoted strings.
+
+### Command-Line Interface
+
+* Don't crash when using `@debug` in a stylesheet passed on standard input.
+
+### Dart API
+
+* `AsyncImporter.canonicalize()` and `Importer.canonicalize()` must now return
+  absolute URLs. Relative URLs are still supported, but are deprecated and will
+  be removed in a future release.
+
+## 1.14.1
+
+* Canonicalize escaped digits at the beginning of identifiers as hex escapes.
+
+* Properly parse property declarations that are both *in* content blocks and
+  written *after* content blocks.
+
+### Command-Line Interface
+
+* Print more readable paths in `--watch` mode.
+
+## 1.14.0
+
+### BREAKING CHANGE
+
+In accordance with our [compatibility policy][], breaking changes made for CSS
+compatibility reasons are released as minor version revision after a three-month
+deprecation period.
+
+[compatibility policy]: README.md#compatibility-policy
+
+* Tokens such as `#abcd` that are now interpreted as hex colors with alpha
+  channels, rather than unquoted ID strings.
+
+## 1.13.4
+
+### Node JS
+
+* Tweak JS compilation options to substantially improve performance.
+
+## 1.13.3
+
+* Properly generate source maps for stylesheets that emit `@charset`
+  declarations.
+
+### Command-Line Interface
+
+* Don't error out when passing `--embed-source-maps` along with
+  `--embed-sources` for stylesheets that contain non-ASCII characters.
+
+## 1.13.2
+
+* Properly parse `:nth-child()` and `:nth-last-child()` selectors with
+  whitespace around the argument.
+
+* Don't emit extra whitespace in the arguments for `:nth-child()` and
+  `:nth-last-child()` selectors.
+
+* Fix support for CSS hacks in plain CSS mode.
+
+## 1.13.1
+
+* Allow an IE-style single equals operator in plain CSS imports.
+
+## 1.13.0
+
+* Allow `@extend` to be used with multiple comma-separated simple selectors.
+  This is already supported by other implementations, but fell through the
+  cracks for Dart Sass until now.
+
+* Don't crash when a media rule contains another media rule followed by a style
+  rule.
+
+## 1.12.0
+
+### Dart API
+
+* Add a `SassException` type that provides information about Sass compilation
+  failures.
+
+### Node JS API
+
+* Remove the source map comment from the compiled JS. We don't ship with the
+  source map, so this pointed to nothing.
+
+## 1.11.0
+
+* Add support for importing plain CSS files. They can only be imported *without*
+  an extension—for example, `@import "style"` will import `style.css`. Plain CSS
+  files imported this way only support standard CSS features, not Sass
+  extensions.
+
+  See [the proposal][css-import] for details.
+
+* Add support for CSS's `min()` and `max()` [math functions][]. A `min()` and
+  `max()` call will continue to be parsed as a Sass function if it involves any
+  Sass-specific features like variables or function calls, but if it's valid
+  plain CSS (optionally with interpolation) it will be emitted as plain CSS instead.
+
+  See [the proposal][css-min-max] for details.
+
+* Add support for range-format media features like `(10px < width < 100px)`. See
+  [the proposal][media-ranges] for details.
+
+* Normalize escape codes in identifiers so that, for example, `éclair` and
+  `\E9clair` are parsed to the same value. See
+  [the proposal][identifier-escapes] for details.
+
+* Don't choke on a [byte-order mark][] at the beginning of a document when
+  running in JavaScript.
+
+[math functions]: https://drafts.csswg.org/css-values/#math-function
+[css-import]: https://github.com/sass/language/blob/master/accepted/css-imports.md
+[css-min-max]: https://github.com/sass/language/blob/master/accepted/min-max.md
+[media-ranges]: https://github.com/sass/language/blob/master/accepted/media-ranges.md
+[identifier-escapes]: https://github.com/sass/language/blob/master/accepted/identifier-escapes.md
+[byte-order mark]: https://en.wikipedia.org/wiki/Byte_order_mark
+
+### Command-Line Interface
+
+* The `--watch` command now continues to recompile a file after a syntax error
+  has been detected.
+
+### Dart API
+
+* Added a `Syntax` enum to indicate syntaxes for Sass source files.
+
+* The `compile()` and `compileAsync()` functions now parse files with the `.css`
+  extension as plain CSS.
+
+* Added a `syntax` parameter to `compileString()` and `compileStringAsync()`.
+
+* Deprecated the `indented` parameter to `compileString()` and `compileStringAsync()`.
+
+* Added a `syntax` parameter to `new ImporterResult()` and a
+  `ImporterResult.syntax` getter to set the syntax of the source file.
+
+* Deprecated the `indented` parameter to `new ImporterResult()` and the
+  `ImporterResult.indented` getter in favor of `syntax`.
+
+## 1.10.4
+
+### Command-Line Interface
+
+* Fix a Homebrew installation failure.
+
+## 1.10.3
+
+### Command-Line Interface
+
+* Run the Chocolatey script with the correct arguments so it doesn't crash.
+
+## 1.10.2
+
+* No user-visible changes.
+
+## 1.10.1
+
+### Node JS API
+
+* Don't crash when passing both `includePaths` and `importer`.
+
+## 1.10.0
+
+* When two `@media` rules' queries can't be merged, leave nested rules in place
+  for browsers that support them.
+
+* Fix a typo in an error message.
+
+## 1.9.2
+
+### Node JS API
+
+* Produce more readable filesystem errors, such as when a file doesn't exist.
+
+## 1.9.1
+
+### Command-Line Interface
+
+* Don't emit ANSI codes to Windows terminals that don't support them.
+
+* Fix a bug where `--watch` crashed on Mac OS.
+
+## 1.9.0
+
+### Node API
+
+* Add support for `new sass.types.Color(argb)` for creating colors from ARGB hex
+  numbers. This was overlooked when initially adding support for Node Sass's
+  JavaScript API.
+
+## 1.8.0
+
+### Command-Line Interface
+
+* Add a `--poll` flag to make `--watch` mode repeatedly check the filesystem for
+  updates rather than relying on native filesystem notifications.
+
+* Add a `--stop-on-error` flag to stop compiling additional files once an error
+  is encountered.
+
+## 1.7.3
+
+* No user-visible changes.
+
+## 1.7.2
+
+* Add a deprecation warning for `@-moz-document`, except for cases where only an
+  empty `url-prefix()` is used. Support is [being removed from Firefox][] and
+  will eventually be removed from Sass as well.
+
+[being removed from Firefox]: https://www.fxsitecompat.com/en-CA/docs/2018/moz-document-support-has-been-dropped-except-for-empty-url-prefix/
+
+* Fix a bug where `@-moz-document` functions with string arguments weren't being
+  parsed.
+
+### Command-Line Interface
+
+* Don't crash when a syntax error is added to a watched file.
+
+## 1.7.1
+
+* Fix crashes in released binaries.
+
+## 1.7.0
+
+* Emit deprecation warnings for tokens such as `#abcd` that are ambiguous
+  between ID strings and hex colors with alpha channels. These will be
+  interpreted as colors in a release on or after 19 September 2018.
+
+* Parse unambiguous hex colors with alpha channels as colors.
+
+* Fix a bug where relative imports from files on the load path could look in the
+  incorrect location.
+
+## 1.6.2
+
+### Command-Line Interface
+
+* Fix a bug where the source map comment in the generated CSS could refer to the
+  source map file using an incorrect URL.
+
+## 1.6.1
+
+* No user-visible changes.
+
+## 1.6.0
+
+* Produce better errors when expected tokens are missing before a closing brace.
+
+* Avoid crashing when compiling a non-partial stylesheet that exists on the
+  filesystem next to a partial with the same name.
+
+### Command-Line Interface
+
+* Add support for the `--watch`, which watches for changes in Sass files on the
+  filesystem and ensures that the compiled CSS is up-to-date.
+
+* When using `--update`, surface errors when an import doesn't exist even if the
+  file containing the import hasn't been modified.
+
+* When compilation fails, delete the output file rather than leaving an outdated
+  version.
+
+## 1.5.1
+
+* Fix a bug where an absolute Windows path would be considered an `input:output`
+  pair.
+
+* Forbid custom properties that have no values, like `--foo:;`, since they're
+  forbidden by the CSS spec.
+
+## 1.5.0
+
+* Fix a bug where an importer would be passed an incorrectly-resolved URL when
+  handling a relative import.
+
+* Throw an error when an import is ambiguous due to a partial and a non-partial
+  with the same name, or multiple files with different extensions. This matches
+  the standard Sass behavior.
+
+### Command-Line Interface
+
+* Add an `--interactive` flag that supports interactively running Sass
+  expressions (thanks to [Jen Thakar][]!).
+
+[Jen Thakar]: https://github.com/jathak
+
+## 1.4.0
+
+* Improve the error message for invalid semicolons in the indented syntax.
+
+* Properly disallow semicolons after declarations in the indented syntax.
+
+### Command-Line Interface
+
+* Add support for compiling multiple files at once by writing
+  `sass input.scss:output.css`. Note that unlike Ruby Sass, this *always*
+  compiles files by default regardless of when they were modified.
+
+  This syntax also supports compiling entire directories at once. For example,
+  `sass templates/stylesheets:public/css` compiles all non-partial Sass files
+  in `templates/stylesheets` to CSS files in `public/css`.
+
+* Add an `--update` flag that tells Sass to compile only stylesheets that have
+  been (transitively) modified since the CSS file was generated.
+
+### Dart API
+
+* Add `Importer.modificationTime()` and `AsyncImporter.modificationTime()` which
+  report the last time a stylesheet was modified.
+
+### Node API
+
+* Generate source maps when the `sourceMaps` option is set to a string and the
+  `outFile` option is not set.
+
+## 1.3.2
+
+* Add support for `@elseif` as an alias of `@else if`. This is not an
+  intentional feature, so using it will cause a deprecation warning. It will be
+  removed at some point in the future.
+
+## 1.3.1
+
+### Node API
+
+* Fix loading imports relative to stylesheets that were themselves imported
+  though relative include paths.
+
+## 1.3.0
+
+### Command-Line Interface
+
+* Generate source map files by default when writing to disk. This can be
+  disabled by passing `--no-source-map`.
+
+* Add a `--source-map-urls` option to control whether the source file URLs in
+  the generated source map are relative or absolute.
+
+* Add an `--embed-sources` option to embed the contents of all source files in
+  the generated source map.
+
+* Add an `--embed-source-map` option to embed the generated source map as a
+  `data:` URL in the generated CSS.
+
+### Dart API
+
+* Add a `sourceMap` parameter to `compile()`, `compileString()`,
+  `compileAsync()`, and `compileStringAsync()`. This takes a callback that's
+  called with a [`SingleMapping`][] that contains the source map information for
+  the compiled CSS file.
+
+[`SingleMapping`]: https://www.dartdocs.org/documentation/source_maps/latest/source_maps.parser/SingleMapping-class.html
+
+### Node API
+
+* Added support for the `sourceMap`, `omitSourceMapUrl`, `outFile`,
+  `sourceMapContents`, `sourceMapEmbed`, and `sourceMapRoot` options to
+  `render()` and `renderSync()`.
+
+* Fix a bug where passing a relative path to `render()` or `renderSync()` would
+  cause relative imports to break.
+
+* Fix a crash when printing warnings in stylesheets compiled using `render()` or
+  `renderSync()`.
+
+* Fix a bug where format errors were reported badly on Windows.
+
+## 1.2.1
+
+* Always emit units in compressed mode for `0` dimensions other than lengths and
+  angles.
+
+## 1.2.0
+
+* The command-line executable will now create the directory for the resulting
+  CSS if that directory doesn't exist.
+
+* Properly parse `#{$var} -#{$var}` as two separate values in a list rather than
+  one value being subtracted from another.
+
+* Improve the error message for extending compound selectors.
+
+## 1.1.1
+
+* Add a commit that was accidentally left out of 1.1.0.
+
+## 1.1.0
+
+* The command-line executable can now be used to write an output file to disk
+  using `sass input.scss output.css`.
+
+* Use a POSIX-shell-compatible means of finding the location of the `sass` shell
+  script.
+
+## 1.0.0
+
+**Initial stable release.**
+
+### Changes Since 1.0.0-rc.1
+
+* Allow `!` in custom property values ([#260][]).
+
+[#260]: https://github.com/sass/dart-sass/issues/260
+
+#### Dart API
+
+* Remove the deprecated `render()` function.
+
+#### Node API
+
+* Errors are now subtypes of the `Error` type.
+
+* Allow both the `data` and `file` options to be passed to `render()` and
+  `renderSync()` at once. The `data` option will be used as the contents of the
+  stylesheet, and the `file` option will be used as the path for error reporting
+  and relative imports. This matches Node Sass's behavior.
+
+## 1.0.0-rc.1
+
+* Add support for importing an `_index.scss` or `_index.sass` file when
+  importing a directory.
+
+* Add a `--load-path` command-line option (alias `-I`) for passing additional
+  paths to search for Sass files to import.
+
+* Add a `--quiet` command-line option (alias `-q`) for silencing warnings.
+
+* Add an `--indented` command-line option for using the indented syntax with a
+  stylesheet from standard input.
+
+* Don't merge the media queries `not type` and `(feature)`. We had previously
+  been generating `not type and (feature)`, but that's not actually the
+  intersection of the two queries.
+
+* Don't crash on `$x % 0`.
+
+* The standalone executable distributed on GitHub is now named `sass` rather
+  than `dart-sass`. The `dart-sass` executable will remain, with a deprecation
+  message, until 1.0.0 is released.
+
+### Dart API
+
+* Add a `Logger` class that allows users to control how messages are printed by
+  stylesheets.
+
+* Add a `logger` parameter to `compile()`, `compileAsync()`, `compileString()`,
+  and `compileStringAsync()`.
+
+### Node JS API
+
+* Import URLs passed to importers are no longer normalized. For example, if a
+  stylesheet contains `@import "./foo.scss"`, importers will now receive
+  `"./foo.scss"` rather than `"foo.scss"`.
+
+## 1.0.0-beta.5.3
+
+* Support hard tabs in the indented syntax.
+
+* Improve the formatting of comments that don't start on the same line as the
+  opening `/*`.
+
+* Preserve whitespace after `and` in media queries in compressed mode.
+
+### Indented Syntax
+
+* Properly parse multi-line selectors.
+
+* Don't deadlock on `/*` comments.
+
+* Don't add an extra `*/` to comments that already have it.
+
+* Preserve empty lines in `/*` comments.
+
+## 1.0.0-beta.5.2
+
+* Fix a bug where some colors would crash `compressed` mode.
+
+## 1.0.0-beta.5.1
+
+* Add a `compressed` output style.
+
+* Emit a warning when `&&` is used, since it's probably not what the user means.
+
+* `round()` now returns the correct results for negative numbers that should
+  round down.
+
+* `var()` may now be passed in place of multiple arguments to `rgb()`, `rgba()`,
+  `hsl()` and `hsla()`.
+
+* Fix some cases where equivalent numbers wouldn't count as the same keys in
+  maps.
+
+* Fix a bug where multiplication like `(1/1px) * (1px/1)` wouldn't properly
+  cancel out units.
+
+* Fix a bug where dividing by a compatible unit would produce an invalid
+  result.
+
+* Remove a non-`sh`-compatible idiom from the standalone shell script.
+
+### Dart API
+
+* Add a `functions` parameter to `compile()`, `compleString()`,
+  `compileAsync()`, and `compileStringAsync()`. This allows users to define
+  custom functions in Dart that can be invoked from Sass stylesheets.
+
+* Expose the `Callable` and `AsyncCallable` types, which represent functions
+  that can be invoked from Sass.
+
+* Expose the `Value` type and its subclasses, as well as the top-level
+  `sassTrue`, `sassFalse`, and `sassNull` values, which represent Sass values
+  that may be passed into or returned from custom functions.
+
+* Expose the `OutputStyle` enum, and add a `style` parameter to `compile()`,
+  `compleString()`, `compileAsync()`, and `compileStringAsync()` that allows
+  users to control the output style.
+
+### Node JS API
+
+* Support the `functions` option.
+
+* Support the `"compressed"` value for the `outputStyle` option.
+
+## 1.0.0-beta.4
+
+* Support unquoted imports in the indented syntax.
+
+* Fix a crash when `:not(...)` extends a selector that appears in
+  `:not(:not(...))`.
+
+### Node JS API
+
+* Add support for asynchronous importers to `render()` and `renderSync()`.
+
+### Dart API
+
+* Add `compileAsync()` and `compileStringAsync()` methods. These run
+  asynchronously, which allows them to take asynchronous importers (see below).
+
+* Add an `AsyncImporter` class. This allows imports to be resolved
+  asynchronously in case no synchronous APIs are available. `AsyncImporter`s are
+  only compatible with `compileAysnc()` and `compileStringAsync()`.
+
+## 1.0.0-beta.3
+
+* Properly parse numbers with exponents.
+
+* Don't crash when evaluating CSS variables whose names are entirely
+  interpolated (for example, `#{--foo}: ...`).
+
+### Node JS API
+
+* Add support for the `importer` option to `render()` and `renderSync()`.
+  Only synchronous importers are currently supported.
+
+### Dart API
+
+* Added an `Importer` class. This can be extended by users to provide support
+  for custom resolution for `@import` rules.
+
+* Added built-in `FilesystemImporter` and `PackageImporter` implementations that
+  support resolving `file:` and `package:` URLs, respectively.
+
+* Added an `importers` argument to the `compile()` and `compileString()`
+  functions that provides `Importer`s to use when resolving `@import` rules.
+
+* Added a `loadPaths` argument to the `compile()` and `compileString()`
+  functions that provides paths to search for stylesheets when resolving
+  `@import` rules. This is a shorthand for passing `FilesystemImporter`s to the
+  `importers` argument.
+
+## 1.0.0-beta.2
+
+* Add support for the `::slotted()` pseudo-element.
+
+* Generated transparent colors will now be emitted as `rgba(0, 0, 0, 0)` rather
+  than `transparent`. This works around a bug wherein IE incorrectly handles the
+  latter format.
+
+### Command-Line Interface
+
+* Improve the logic for whether to use terminal colors by default.
+
+### Node JS API
+
+* Add support for `data`, `includePaths`, `indentedSyntax`, `lineFeed`,
+  `indentWidth`, and `indentType` options to `render()` and `renderSync()`.
+
+* The result object returned by `render()` and `renderSync()` now includes the
+  `stats` object which provides metadata about the compilation process.
+
+* The error object thrown by `render()` and `renderSync()` now includes `line`,
+  `column`, `file`, `status`, and `formatted` fields. The `message` field and
+  `toString()` also provide more information.
+
+### Dart API
+
+* Add a `renderString()` method for rendering Sass source that's not in a file
+  on disk.
+
+## 1.0.0-beta.1
+
+* Drop support for the reference combinator. This has been removed from the
+  spec, and will be deprecated and eventually removed in other implementations.
+
+* Trust type annotations when compiling to JavaScript, which makes it
+  substantially faster.
+
+* Compile to minified JavaScript, which decreases the code size substantially
+  and makes startup a little faster.
+
+* Fix a crash when inspecting a string expression that ended in "\a".
+
+* Fix a bug where declarations and `@extend` were allowed outside of a style
+  rule in certain circumstances.
+
+* Fix `not` in parentheses in `@supports` conditions.
+
+* Allow `url` as an identifier name.
+
+* Properly parse `/***/` in selectors.
+
+* Properly parse unary operators immediately after commas.
+
+* Match Ruby Sass's rounding behavior for all functions.
+
+* Allow `\` at the beginning of a selector in the indented syntax.
+
+* Fix a number of `@extend` bugs:
+
+  * `selector-extend()` and `selector-replace()` now allow compound selector
+    extendees.
+
+  * Remove the universal selector `*` when unifying with other selectors.
+
+  * Properly unify the result of multiple simple selectors in the same compound
+    selector being extended.
+
+  * Properly handle extensions being extended.
+
+  * Properly follow the [first law of `@extend`][laws].
+
+  * Fix selector specificity tracking to follow the
+    [second law of `@extend`][laws].
+
+  * Allow extensions that match selectors but fail to unify.
+
+  * Partially-extended selectors are no longer used as parent selectors.
+
+  * Fix an edge case where both the extender and the extended selector
+    have invalid combinator sequences.
+
+  * Don't crash with a "Bad state: no element" error in certain edge cases.
+
+[laws]: https://github.com/sass/sass/issues/324#issuecomment-4607184
+
+## 1.0.0-alpha.9
+
+* Elements without a namespace (such as `div`) are no longer unified with
+  elements with the empty namespace (such as `|div`). This unification didn't
+  match the results returned by `is-superselector()`, and was not guaranteed to
+  be valid.
+
+* Support `&` within `@at-root`.
+
+* Properly error when a compound selector is followed immediately by `&`.
+
+* Properly handle variable scoping in `@at-root` and nested properties.
+
+* Properly handle placeholder selectors in selector pseudos.
+
+* Properly short-circuit the `or` and `and` operators.
+
+* Support `--$variable`.
+
+* Don't consider unitless numbers equal to numbers with units.
+
+* Warn about using named colors in interpolation.
+
+* Don't emit loud comments in functions.
+
+* Detect import loops.
+
+* Fix `@import` with a `supports()` clause.
+
+* Forbid functions named "and", "or", and "not".
+
+* Fix `type-of()` with a function.
+
+* Emit a nicer error for invalid tokens in a selector.
+
+* Fix `invert()` with a `$weight` parameter.
+
+* Fix a unit-parsing edge-cases.
+
+* Always parse imports with queries as plain CSS imports.
+
+* Support `&` followed by a non-identifier.
+
+* Properly handle split media queries.
+
+* Properly handle a placeholder selector that isn't at the beginning of a
+  compound selector.
+
+* Fix more `str-slice()` bugs.
+
+* Fix the `%` operator.
+
+* Allow whitespace between `=` and the mixin name in the indented syntax.
+
+* Fix some slash division edge cases.
+
+* Fix `not` when used like a function.
+
+* Fix attribute selectors with single-character values.
+
+* Fix some bugs with the `call()` function.
+
+* Properly handle a backslash followed by a CRLF sequence in a quoted string.
+
+* Fix numbers divided by colors.
+
+* Support slash-separated numbers in arguments to plain CSS functions.
+
+* Error out if a function is passed an unknown named parameter.
+
+* Improve the speed of loading large files on Node.
+
+* Don't consider browser-prefixed selector pseudos to be superselectors of
+  differently- or non-prefixed selector pseudos with the same base name.
+
+* Fix an `@extend` edge case involving multiple combinators in a row.
+
+* Fix a bug where a `@content` block could get incorrectly passed to a mixin.
+
+* Properly isolate the lexical environments of different calls to the same mixin
+  and function.
+
+## 1.0.0-alpha.8
+
+* Add the `content-exists()` function.
+
+* Support interpolation in loud comments.
+
+* Fix a bug where even valid semicolons and exclamation marks in custom property
+  values were disallowed.
+
+* Disallow invalid function names.
+
+* Disallow extending across media queries.
+
+* Properly parse whitespace after `...` in argument declaration lists.
+
+* Support terse mixin syntax in the indented syntax.
+
+* Fix `@at-root` query parsing.
+
+* Support special functions in `@-moz-document`.
+
+* Support `...` after a digit.
+
+* Fix some bugs when treating a map as a list of pairs.
+
+## 1.0.0-alpha.7
+
+* Fix `function-exists()`, `variable-exists()`, and `mixin-exists()` to use the
+  lexical scope rather than always using the global scope.
+
+* `str-index()` now correctly inserts at negative indices.
+
+* Properly parse `url()`s that contain comment-like text.
+
+* Fix a few more small `@extend` bugs.
+
+* Fix a bug where interpolation in a quoted string was being dropped in some
+  circumstances.
+
+* Properly handle `@for` rules where each bound has a different unit.
+
+* Forbid mixins and functions from being defined in control directives.
+
+* Fix a superselector-computation edge case involving `:not()`.
+
+* Gracefully handle input files that are invalid UTF-8.
+
+* Print a Sass stack trace when a file fails to load.
+
+## 1.0.0-alpha.6
+
+* Allow `var()` to be passed to `rgb()`, `rgba()`, `hsl()`, and `hsla()`.
+
+* Fix conversions between numbers with `dpi`, `dpcm`, and `dppx` units.
+  Previously these conversions were inverted.
+
+* Don't crash when calling `str-slice()` with an `$end-at` index lower than the
+  `$start-at` index.
+
+* `str-slice()` now correctly returns `""` when `$end-at` is negative and points
+  before the beginning of the string.
+
+* Interpolation in quoted strings now properly preserves newlines.
+
+* Don't crash when passing only `$hue` or no keyword arguments to
+  `adjust-color()`, `scale-color()`, or `change-color()`.
+
+* Preserve escapes in identifiers. This used to only work for identifiers in
+  SassScript.
+
+* Fix a few small `@extend` bugs.
+
+## 1.0.0-alpha.5
+
+* Fix bounds-checking for `opacify()`, `fade-in()`, `transparentize()`, and
+  `fade-out()`.
+
+* Fix a bug with `@extend` superselector calculations.
+
+* Fix some cases where `#{...}--` would fail to parse in selectors.
+
+* Allow a single number to be passed to `saturate()` for use in filter contexts.
+
+* Fix a bug where `**/` would fail to close a loud comment.
+
+* Fix a bug where mixin and function calls could set variables incorrectly.
+
+* Move plain CSS `@import`s to the top of the document.
+
+## 1.0.0-alpha.4
+
+* Add support for bracketed lists.
+
+* Add support for Unicode ranges.
+
+* Add support for the Microsoft-style `=` operator.
+
+* Print the filename for `@debug` rules.
+
+* Fix a bug where `1 + - 2` and similar constructs would crash the parser.
+
+* Fix a bug where `@extend` produced the wrong result when used with
+  selector combinators.
+
+* Fix a bug where placeholder selectors were not allowed to be unified.
+
+* Fix the `mixin-exists()` function.
+
+* Fix `:nth-child()` and `:nth-last-child()` parsing when they contain `of
+  selector`.
+
+## 1.0.0-alpha.3
+
+* Fix a bug where color equality didn't take the alpha channel into account.
+
+* Fix a bug with converting some RGB colors to HSL.
+
+* Fix a parent selector resolution bug.
+
+* Properly declare the arguments for `opacify()` and related functions.
+
+* Add a missing dependency on the `stack_trace` package.
+
+* Fix broken Windows archives.
+
+* Emit colors using their original representation if possible.
+
+* Emit colors without an original representation as names if possible.
+
+## 1.0.0-alpha.2
+
+* Fix a bug where variables, functions, and mixins were broken in imported
+  files.
+
+## 1.0.0-alpha.1
+
+* Initial alpha release.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+Sass is more than a technology; Sass is driven by the community of individuals
+that power its development and use every day. As a community, we want to embrace
+the very differences that have made our collaboration so powerful, and work
+together to provide the best environment for learning, growing, and sharing of
+ideas. It is imperative that we keep Sass a fun, welcoming, challenging, and
+fair place to play.
+
+[The full community guidelines can be found on the Sass website.][link]
+
+[link]: http://sass-lang.com/community-guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution;
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Release process
+
+Because this package's version remains in lockstep with the current version of
+Dart Sass, it's not released manually from this repository. Instead, a release
+commit is automatically generated once a new Embedded Dart Sass version has been
+released, which in turn is automatically triggered by a release of Dart Sass. As
+such, manual commits should never:
+
+* Update the `package.json`'s version to a non-`-dev` number. Changing it from
+  non-`-dev` to dev when adding a new feature is fine.
+
+* Update the `package.json`'s `"compiler-version"` field to a non-`-dev` number.
+  Changing it from non-`-dev` to dev when using a new feature is fine.
+
+# Keeping in Sync With Other Packages
+
+The embedded host depends on several different components which come from
+different repositories:
+
+* The [Dart Sass embedded compiler].
+* [Dart Sass] (transitively through the embedded compiler).
+* The [Sass embedded protocol].
+* The [Sass JS API definition].
+
+[Dart Sass embedded compiler]: https://github.com/sass/dart-sass-embedded
+[Dart Sass]: https://github.com/sass/dart-sass
+[Sass embedded protocol]: https://github.com/sass/embedded-protocol
+[JS API definition]: https://github.com/sass/sass/tree/main/spec/js-api
+
+These dependencies are made available in different ways depending on context.
+
+## Local Development
+
+When developing locally, you can download all of these dependencies by running
+`npm run init`. This provides the following options for `compiler` (for the
+embedded compiler), `protocol` (for the embedded protocol), and `api` (for the
+JS API):
+
+* `--<type>-path`: The local filesystem path of the package to use. This is
+  useful when doing local development on both the host and its dependencies at
+  the same time.
+
+* `--<type>-ref`: A Git reference for the GitHub repository of the package to
+  clone.
+
+By default:
+
+* This uses the version of the embedded protocol and compiler specified by
+  `protocol-version` in `package.json`, *unless* that version ends in `-dev` in
+  which case it checks out the latest revision on GitHub.
+
+* This uses the embedded compiler version and JS API definition from the latest
+  revision on GitHub.
+
+* This uses the Dart Sass version from the latest revision on GitHub, unless the
+  embedded `--compiler-path` was passed in which case it uses whatever version
+  of Dart Sass that package references.
+
+## Continuous Integration
+
+CI tests also use `npm run init`, so they use the same defaults as local
+development. However, if the pull request description includes a link to a pull
+request for the embedded compiler, Dart Sass, the embedded protocol, or the JS
+API, this will check out that version and run tests against it instead.
+
+## Release
+
+When this package is released to npm, it downloads the embedded protocol version
+that matches `protocol-version` in `package.json`. It downloads the latest JS
+API revision on GitHub.
+
+The release version of the `sass-embedded` package does *not* include the
+embedded compiler or Dart Sass. Instead, we release optional packages of the
+form `sass-embedded-<os>-<arch>`. Each of these contains the published version
+of the embedded compiler that matches `compiler-version` in `package.json` for
+the given operating system/architecture combination.
+
+If either `protocol-version` or `compiler-version` ends with `-dev`, the release
+will fail.
+
+**Note:** As part of the holistic release process for Dart Sass, the embedded
+compiler's CI will automatically update this repository's `package.json` file
+with the latest `compiler-version` and optional dependency versions before
+tagging it for a release.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2019, Google LLC
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,99 @@
+## Embedded Sass Host
+
+This package is an alternative to the [`sass`] package. It supports the same JS
+API as `sass` and is maintained by the same team, but where the `sass` package
+is pure JavaScript, `sass-embedded` is instead a JavaScript wrapper around a
+native Dart executable. This means `sass-embedded` will generally be much faster
+especially for large Sass compilations, but it can only be installed on the
+platforms that Dart supports: Windows, Mac OS, and Linux.
+
+[`sass`]: https://www.npmjs.com/package/sass
+
+Despite being different packages, both `sass` and `sass-embedded` are considered
+"Dart Sass" since they have the same underlying implementation. Since the first
+stable release of the `sass-embedded` package, both packages are released at the
+same time and share the same version number.
+
+## Usage
+
+This package provides the same JavaScript API as the `sass` package, and can be
+used as a drop-in replacement:
+
+```js
+const sass = require('sass-embedded');
+
+const result = sass.compile(scssFilename);
+
+// OR
+
+const result = await sass.compileAsync(scssFilename);
+```
+
+Unlike the `sass` package, the asynchronous API in `sass-embedded` will
+generally be faster than the synchronous API since the Sass compilation logic is
+happening in a different process.
+
+See [the Sass website] for full API documentation.
+
+[the Sass website]: https://sass-lang.com/documentation/js-api
+
+### Legacy API
+
+The `sass-embedded` package also supports the older JavaScript API that's fully
+compatible with [Node Sass] (with a few exceptions listed below), with support
+for both the [`render()`] and [`renderSync()`] functions. This API is considered
+deprecated and will be removed in Dart Sass 2.0.0, so it should be avoided in
+new projects.
+
+[Node Sass]: https://github.com/sass/node-sass
+[`render()`]: https://sass-lang.com/documentation/js-api/modules#render
+[`renderSync()`]: https://sass-lang.com/documentation/js-api/modules#renderSync
+
+Sass's support for the legacy JavaScript API has the following limitations:
+
+* Only the `"expanded"` and `"compressed"` values of [`outputStyle`] are
+  supported.
+
+* The `sass-embedded` package doesn't support the [`precision`] option. Dart
+  Sass defaults to a sufficiently high precision for all existing browsers, and
+  making this customizable would make the code substantially less efficient.
+
+* The `sass-embedded` package doesn't support the [`sourceComments`] option.
+  Source maps are the recommended way of locating the origin of generated
+  selectors.
+
+* The `sass-embedded` package doesn't support the [`indentWidth`],
+  [`indentType`], or [`linefeed`] options. It implements the legacy API as a
+  wrapper around the new API, and the new API has dropped support for these
+  options.
+
+[`outputStyle`]: https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions#outputStyle
+[`precision`]: https://github.com/sass/node-sass#precision
+[`indentWidth`]: https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions#indentWidth
+[`indentType`]: https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions#indentType
+[`linefeed`]: https://sass-lang.com/documentation/js-api/interfaces/LegacySharedOptions#linefeed
+
+## How Does It Work?
+
+The `sass-embedded` runs the Dart Sass [embedded compiler] as a separate
+executable and uses the [Embedded Sass Protocol] to communicate with it over its
+stdin and stdout streams. This protocol is designed to make it possible not only
+to start a Sass compilation, but to control aspects of it that are exposed by an
+API. This includes defining custom importers, functions, and loggers, all of
+which are invoked by messages from the embedded compiler back to the host.
+
+[embedded compiler]: https://github.com/sass/dart-sass-embedded
+[Embedded Sass Protocol]: https://github.com/sass/embedded-protocol#readme
+
+Although this sort of two-way communication with an embedded process is
+inherently asynchronous in Node.js, this package supports the synchronous
+`compile()` API using a custom [synchronous message-passing library] that's
+implemented with the [`Atomics.wait()`] primitive. We hope to release this
+library as a stand-alone package at some point in the future.
+
+[synchronous message-passing library]: https://github.com/sass/embedded-host-node/blob/main/lib/src/sync-process/sync-message-port.ts
+[`Atomics.wait()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait
+
+---
+
+Disclaimer: this is not an official Google product.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,6 @@
+const config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};
+
+export default config;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,40 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as pkg from '../package.json';
+import {sassFalse, sassTrue} from './src/value/boolean';
+import {sassNull} from './src/value/null';
+
+export {ListSeparator, SassList} from './src/value/list';
+export {SassArgumentList} from './src/value/argument-list';
+export {sassFalse, sassTrue} from './src/value/boolean';
+export {SassColor} from './src/value/color';
+export {SassFunction} from './src/value/function';
+export {SassMap} from './src/value/map';
+export {SassNumber} from './src/value/number';
+export {SassString} from './src/value/string';
+export {Value} from './src/value';
+export {sassNull} from './src/value/null';
+
+export * as types from './src/legacy/value';
+export {Exception} from './src/exception';
+export {
+  compile,
+  compileString,
+  compileAsync,
+  compileStringAsync,
+} from './src/compile';
+export {render, renderSync} from './src/legacy';
+
+export const info = `sass-embedded\t${pkg.version}`;
+
+export const Logger = {
+  silent: {warn() {}, debug() {}},
+};
+
+// Legacy JS API
+
+export const TRUE = sassTrue;
+export const FALSE = sassFalse;
+export const NULL = sassNull;

--- a/lib/src/async-compiler.ts
+++ b/lib/src/async-compiler.ts
@@ -1,0 +1,43 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {spawn} from 'child_process';
+import {Observable} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+
+import {compilerPath} from './compiler-path';
+
+/**
+ * An asynchronous wrapper for the embedded Sass compiler that exposes its stdio
+ * streams as Observables.
+ */
+export class AsyncEmbeddedCompiler {
+  /** The underlying process that's being wrapped. */
+  private readonly process = spawn(compilerPath, {windowsHide: true});
+
+  /** The child process's exit event. */
+  readonly exit$ = new Promise<number | null>(resolve => {
+    this.process.on('exit', code => resolve(code));
+  });
+
+  /** The buffers emitted by the child process's stdout. */
+  readonly stdout$ = new Observable<Buffer>(observer => {
+    this.process.stdout.on('data', buffer => observer.next(buffer));
+  }).pipe(takeUntil(this.exit$));
+
+  /** The buffers emitted by the child process's stderr. */
+  readonly stderr$ = new Observable<Buffer>(observer => {
+    this.process.stderr.on('data', buffer => observer.next(buffer));
+  }).pipe(takeUntil(this.exit$));
+
+  /** Writes `buffer` to the child process's stdin. */
+  writeStdin(buffer: Buffer): void {
+    this.process.stdin.write(buffer);
+  }
+
+  /** Kills the child process, cleaning up all associated Observables. */
+  close() {
+    this.process.stdin.end();
+  }
+}

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -1,0 +1,323 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as p from 'path';
+import {Observable} from 'rxjs';
+import * as supportsColor from 'supports-color';
+
+import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as utils from './utils';
+import {AsyncEmbeddedCompiler} from './async-compiler';
+import {CompileResult, Options, SourceSpan, StringOptions} from './vendor/sass';
+import {Dispatcher, DispatcherHandlers} from './dispatcher';
+import {Exception} from './exception';
+import {FunctionRegistry} from './function-registry';
+import {ImporterRegistry} from './importer-registry';
+import {MessageTransformer} from './message-transformer';
+import {PacketTransformer} from './packet-transformer';
+import {SyncEmbeddedCompiler} from './sync-compiler';
+import {deprotofySourceSpan} from './deprotofy-span';
+import {legacyImporterProtocol} from './legacy/importer';
+
+export function compile(
+  path: string,
+  options?: Options<'sync'>
+): CompileResult {
+  const importers = new ImporterRegistry(options);
+  return compileRequestSync(
+    newCompilePathRequest(path, importers, options),
+    importers,
+    options
+  );
+}
+
+export function compileString(
+  source: string,
+  options?: StringOptions<'sync'>
+): CompileResult {
+  const importers = new ImporterRegistry(options);
+  return compileRequestSync(
+    newCompileStringRequest(source, importers, options),
+    importers,
+    options
+  );
+}
+
+export function compileAsync(
+  path: string,
+  options?: Options<'async'>
+): Promise<CompileResult> {
+  const importers = new ImporterRegistry(options);
+  return compileRequestAsync(
+    newCompilePathRequest(path, importers, options),
+    importers,
+    options
+  );
+}
+
+export function compileStringAsync(
+  source: string,
+  options?: StringOptions<'async'>
+): Promise<CompileResult> {
+  const importers = new ImporterRegistry(options);
+  return compileRequestAsync(
+    newCompileStringRequest(source, importers, options),
+    importers,
+    options
+  );
+}
+
+// Creates a request for compiling a file.
+function newCompilePathRequest(
+  path: string,
+  importers: ImporterRegistry<'sync' | 'async'>,
+  options?: Options<'sync' | 'async'>
+): proto.InboundMessage.CompileRequest {
+  const request = newCompileRequest(importers, options);
+  request.setPath(path);
+  return request;
+}
+
+// Creates a request for compiling a string.
+function newCompileStringRequest(
+  source: string,
+  importers: ImporterRegistry<'sync' | 'async'>,
+  options?: StringOptions<'sync' | 'async'>
+): proto.InboundMessage.CompileRequest {
+  const input = new proto.InboundMessage.CompileRequest.StringInput();
+  input.setSource(source);
+  input.setSyntax(utils.protofySyntax(options?.syntax ?? 'scss'));
+
+  const url = options?.url?.toString();
+  if (url && url !== legacyImporterProtocol) {
+    input.setUrl(url);
+  }
+
+  if (options && 'importer' in options && options.importer) {
+    input.setImporter(importers.register(options.importer));
+  } else if (url === legacyImporterProtocol) {
+    const importer = new proto.InboundMessage.CompileRequest.Importer();
+    importer.setPath(p.resolve('.'));
+    input.setImporter(importer);
+  } else {
+    // When importer is not set on the host, the compiler will set a
+    // FileSystemImporter if `url` is set to a file: url or a NoOpImporter.
+  }
+
+  const request = newCompileRequest(importers, options);
+  request.setString(input);
+  return request;
+}
+
+// Creates a compilation request for the given `options` without adding any
+// input-specific options.
+function newCompileRequest(
+  importers: ImporterRegistry<'sync' | 'async'>,
+  options?: Options<'sync' | 'async'>
+): proto.InboundMessage.CompileRequest {
+  const request = new proto.InboundMessage.CompileRequest();
+  request.setImportersList(importers.importers);
+  request.setGlobalFunctionsList(Object.keys(options?.functions ?? {}));
+  request.setSourceMap(!!options?.sourceMap);
+  request.setSourceMapIncludeSources(!!options?.sourceMapIncludeSources);
+  request.setAlertColor(options?.alertColor ?? !!supportsColor.stdout);
+  request.setAlertAscii(!!options?.alertAscii);
+  request.setQuietDeps(!!options?.quietDeps);
+  request.setVerbose(!!options?.verbose);
+  request.setCharset(!!(options?.charset ?? true));
+
+  switch (options?.style ?? 'expanded') {
+    case 'expanded':
+      request.setStyle(proto.OutputStyle.EXPANDED);
+      break;
+
+    case 'compressed':
+      request.setStyle(proto.OutputStyle.COMPRESSED);
+      break;
+
+    default:
+      throw new Error(`Unknown options.style: "${options?.style}"`);
+  }
+
+  return request;
+}
+
+// Spins up a compiler, then sends it a compile request. Returns a promise that
+// resolves with the CompileResult. Throws if there were any protocol or
+// compilation errors. Shuts down the compiler after compilation.
+async function compileRequestAsync(
+  request: proto.InboundMessage.CompileRequest,
+  importers: ImporterRegistry<'async'>,
+  options?: Options<'async'>
+): Promise<CompileResult> {
+  const functions = new FunctionRegistry(options?.functions);
+  const embeddedCompiler = new AsyncEmbeddedCompiler();
+  embeddedCompiler.stderr$.subscribe(data => process.stderr.write(data));
+
+  try {
+    const dispatcher = createDispatcher<'async'>(
+      embeddedCompiler.stdout$,
+      buffer => {
+        embeddedCompiler.writeStdin(buffer);
+      },
+      {
+        handleImportRequest: request => importers.import(request),
+        handleFileImportRequest: request => importers.fileImport(request),
+        handleCanonicalizeRequest: request => importers.canonicalize(request),
+        handleFunctionCallRequest: request => functions.call(request),
+      }
+    );
+
+    dispatcher.logEvents$.subscribe(event => handleLogEvent(options, event));
+
+    return handleCompileResponse(
+      await new Promise<proto.OutboundMessage.CompileResponse>(
+        (resolve, reject) =>
+          dispatcher.sendCompileRequest(request, (err, response) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(response!);
+            }
+          })
+      )
+    );
+  } finally {
+    embeddedCompiler.close();
+    await embeddedCompiler.exit$;
+  }
+}
+
+// Spins up a compiler, then sends it a compile request. Returns a promise that
+// resolves with the CompileResult. Throws if there were any protocol or
+// compilation errors. Shuts down the compiler after compilation.
+function compileRequestSync(
+  request: proto.InboundMessage.CompileRequest,
+  importers: ImporterRegistry<'sync'>,
+  options?: Options<'sync'>
+): CompileResult {
+  const functions = new FunctionRegistry(options?.functions);
+  const embeddedCompiler = new SyncEmbeddedCompiler();
+  embeddedCompiler.stderr$.subscribe(data => process.stderr.write(data));
+
+  try {
+    const dispatcher = createDispatcher<'sync'>(
+      embeddedCompiler.stdout$,
+      buffer => {
+        embeddedCompiler.writeStdin(buffer);
+      },
+      {
+        handleImportRequest: request => importers.import(request),
+        handleFileImportRequest: request => importers.fileImport(request),
+        handleCanonicalizeRequest: request => importers.canonicalize(request),
+        handleFunctionCallRequest: request => functions.call(request),
+      }
+    );
+
+    dispatcher.logEvents$.subscribe(event => handleLogEvent(options, event));
+
+    let error: unknown;
+    let response: proto.OutboundMessage.CompileResponse | undefined;
+    dispatcher.sendCompileRequest(request, (error_, response_) => {
+      if (error_) {
+        error = error_;
+      } else {
+        response = response_;
+      }
+    });
+
+    for (;;) {
+      if (!embeddedCompiler.yield()) {
+        throw utils.compilerError('Embedded compiler exited unexpectedly.');
+      }
+
+      if (error) throw error;
+      if (response) return handleCompileResponse(response);
+    }
+  } finally {
+    embeddedCompiler.close();
+    embeddedCompiler.yieldUntilExit();
+  }
+}
+
+/**
+ * Creates a dispatcher that dispatches messages from the given `stdout` stream.
+ */
+function createDispatcher<sync extends 'sync' | 'async'>(
+  stdout: Observable<Buffer>,
+  writeStdin: (buffer: Buffer) => void,
+  handlers: DispatcherHandlers<sync>
+): Dispatcher<sync> {
+  const packetTransformer = new PacketTransformer(stdout, writeStdin);
+
+  const messageTransformer = new MessageTransformer(
+    packetTransformer.outboundProtobufs$,
+    packet => packetTransformer.writeInboundProtobuf(packet)
+  );
+
+  return new Dispatcher<sync>(
+    messageTransformer.outboundMessages$,
+    message => messageTransformer.writeInboundMessage(message),
+    handlers
+  );
+}
+
+/** Handles a log event according to `options`. */
+function handleLogEvent(
+  options: Options<'sync' | 'async'> | undefined,
+  event: proto.OutboundMessage.LogEvent
+): void {
+  if (event.getType() === proto.LogEventType.DEBUG) {
+    if (options?.logger?.debug) {
+      options.logger.debug(event.getMessage(), {
+        span: deprotofySourceSpan(event.getSpan()!),
+      });
+    } else {
+      console.error(event.getFormatted());
+    }
+  } else {
+    if (options?.logger?.warn) {
+      const params: {deprecation: boolean; span?: SourceSpan; stack?: string} =
+        {
+          deprecation:
+            event.getType() === proto.LogEventType.DEPRECATION_WARNING,
+        };
+
+      const spanProto = event.getSpan();
+      if (spanProto) params.span = deprotofySourceSpan(spanProto);
+
+      const stack = event.getStackTrace();
+      if (stack) params.stack = stack;
+
+      options.logger.warn(event.getMessage(), params);
+    } else {
+      console.error(event.getFormatted());
+    }
+  }
+}
+
+/**
+ * Converts a `CompileResponse` into a `CompileResult`.
+ *
+ * Throws a `SassException` if the compilation failed.
+ */
+function handleCompileResponse(
+  response: proto.OutboundMessage.CompileResponse
+): CompileResult {
+  if (response.getSuccess()) {
+    const success = response.getSuccess()!;
+    const result: CompileResult = {
+      css: success.getCss(),
+      loadedUrls: success.getLoadedUrlsList().map(url => new URL(url)),
+    };
+
+    const sourceMap = success.getSourceMap();
+    if (sourceMap) result.sourceMap = JSON.parse(sourceMap);
+    return result;
+  } else if (response.getFailure()) {
+    throw new Exception(response.getFailure()!);
+  } else {
+    throw utils.compilerError('Compiler sent empty CompileResponse.');
+  }
+}

--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -1,0 +1,42 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as fs from 'fs';
+import * as p from 'path';
+import {isErrnoException} from './utils';
+
+/** The path to the embedded compiler executable. */
+export const compilerPath = (() => {
+  // find for development
+  for (const path of ['vendor', '../../../lib/src/vendor']) {
+    const executable = p.resolve(
+      __dirname,
+      path,
+      `dart-sass-embedded/dart-sass-embedded${
+        process.platform === 'win32' ? '.bat' : ''
+      }`
+    );
+
+    if (fs.existsSync(executable)) return executable;
+  }
+
+  try {
+    return require.resolve(
+      `sass-embedded-${process.platform}-${process.arch}/` +
+        'dart-sass-embedded/dart-sass-embedded' +
+        (process.platform === 'win32' ? '.bat' : '')
+    );
+  } catch (e: unknown) {
+    if (!(isErrnoException(e) && e.code === 'MODULE_NOT_FOUND')) {
+      throw e;
+    }
+  }
+
+  throw new Error(
+    "Embedded Dart Sass couldn't find the embedded compiler executable. " +
+      'Please make sure the optional dependency ' +
+      `sass-embedded-${process.platform}-${process.arch} is installed in ` +
+      'node_modules.'
+  );
+})();

--- a/lib/src/deprotofy-span.ts
+++ b/lib/src/deprotofy-span.ts
@@ -1,0 +1,57 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {URL} from 'url';
+
+import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import {SourceLocation, SourceSpan} from './vendor/sass';
+import {compilerError} from './utils';
+
+// Creates a SourceSpan from the given protocol `buffer`. Throws if the buffer
+// has invalid fields.
+export function deprotofySourceSpan(buffer: proto.SourceSpan): SourceSpan {
+  const text = buffer.getText();
+
+  if (buffer.getStart() === undefined) {
+    throw compilerError('Expected SourceSpan to have start.');
+  }
+  const start = deprotofySourceLocation(buffer.getStart()!);
+
+  let end;
+  if (buffer.getEnd() === undefined) {
+    if (text !== '') {
+      throw compilerError('Expected SourceSpan text to be empty.');
+    } else {
+      end = start;
+    }
+  } else {
+    end = deprotofySourceLocation(buffer.getEnd()!);
+    if (end.offset < start.offset) {
+      throw compilerError('Expected SourceSpan end to be after start.');
+    }
+  }
+
+  const url = buffer.getUrl() === '' ? undefined : new URL(buffer.getUrl());
+
+  const context = buffer.getContext() === '' ? undefined : buffer.getContext();
+
+  return {
+    text,
+    start,
+    end,
+    url,
+    context,
+  };
+}
+
+// Creates a SourceLocation from the given protocol `buffer`.
+function deprotofySourceLocation(
+  buffer: proto.SourceSpan.SourceLocation
+): SourceLocation {
+  return {
+    offset: buffer.getOffset(),
+    line: buffer.getLine(),
+    column: buffer.getColumn(),
+  };
+}

--- a/lib/src/dispatcher.ts
+++ b/lib/src/dispatcher.ts
@@ -1,0 +1,292 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {Observable, Subject} from 'rxjs';
+import {filter, map, mergeMap} from 'rxjs/operators';
+
+import {
+  InboundMessage,
+  OutboundMessage,
+} from './vendor/embedded-protocol/embedded_sass_pb';
+import {
+  InboundRequest,
+  InboundRequestType,
+  InboundResponse,
+  InboundResponseType,
+  InboundTypedMessage,
+  OutboundResponse,
+  OutboundResponseType,
+  OutboundTypedMessage,
+} from './message-transformer';
+import {RequestTracker} from './request-tracker';
+import {PromiseOr, thenOr} from './utils';
+
+/**
+ * Dispatches requests, responses, and events.
+ *
+ * Accepts callbacks for processing different types of outbound requests. When
+ * an outbound request arrives, this runs the appropriate callback to process
+ * it, and then sends the result inbound. A single callback must be provided for
+ * each outbound request type. The callback does not need to set the response
+ * ID; the dispatcher handles it.
+ *
+ * Consumers can send an inbound request. This returns a promise that will
+ * either resolve with the corresponding outbound response, or error if any
+ * Protocol Errors were encountered. The consumer does not need to set the
+ * request ID; the dispatcher handles it.
+ *
+ * Outbound events are exposed as Observables.
+ *
+ * Errors are not otherwise exposed to the top-level. Instead, they are surfaced
+ * as an Observable that consumers may choose to subscribe to. Subscribers must
+ * perform proper error handling.
+ */
+export class Dispatcher<sync extends 'sync' | 'async'> {
+  // Tracks the IDs of all inbound requests. An outbound response with matching
+  // ID and type will remove the ID.
+  private readonly pendingInboundRequests = new RequestTracker();
+
+  // Tracks the IDs of all outbound requests. An inbound response with matching
+  // ID and type will remove the ID.
+  private readonly pendingOutboundRequests = new RequestTracker();
+
+  // All outbound messages. If we detect any errors while dispatching messages,
+  // this completes.
+  private readonly messages$ = new Subject<OutboundTypedMessage>();
+
+  // If the dispatcher encounters an error, this errors out. It is publicly
+  // exposed as a readonly Observable.
+  private readonly errorInternal$ = new Subject<void>();
+
+  /**
+   * If the dispatcher encounters an error, this errors out. Upon error, the
+   * dispatcher rejects all promises awaiting an outbound response, and silently
+   * closes all subscriptions to outbound events.
+   */
+  readonly error$ = this.errorInternal$.pipe();
+
+  /**
+   * Outbound log events. If an error occurs, the dispatcher closes this
+   * silently.
+   */
+  readonly logEvents$ = this.messages$.pipe(
+    filter(message => message.type === OutboundMessage.MessageCase.LOG_EVENT),
+    map(message => message.payload as OutboundMessage.LogEvent)
+  );
+
+  constructor(
+    private readonly outboundMessages$: Observable<OutboundTypedMessage>,
+    private readonly writeInboundMessage: (
+      message: InboundTypedMessage
+    ) => void,
+    private readonly outboundRequestHandlers: DispatcherHandlers<sync>
+  ) {
+    this.outboundMessages$
+      .pipe(
+        mergeMap(message => {
+          const result = this.handleOutboundMessage(message);
+          return result instanceof Promise
+            ? result.then(() => message)
+            : [message];
+        })
+      )
+      .subscribe({
+        next: message => this.messages$.next(message),
+        error: error => this.throwAndClose(error),
+        complete: () => {
+          this.messages$.complete();
+          this.errorInternal$.complete();
+        },
+      });
+  }
+
+  /**
+   * Sends a CompileRequest inbound. Passes the corresponding outbound
+   * CompileResponse or an error to `callback`.
+   *
+   * This uses an old-style callback argument so that it can work either
+   * synchronously or asynchronously. If the underlying stdout stream emits
+   * events synchronously, `callback` will be called synchronously.
+   */
+  sendCompileRequest(
+    request: InboundMessage.CompileRequest,
+    callback: (
+      err: unknown,
+      response: OutboundMessage.CompileResponse | undefined
+    ) => void
+  ): void {
+    this.handleInboundRequest(
+      request,
+      InboundMessage.MessageCase.COMPILE_REQUEST,
+      OutboundMessage.MessageCase.COMPILE_RESPONSE,
+      callback
+    );
+  }
+
+  // Rejects with `error` all promises awaiting an outbound response, and
+  // silently closes all subscriptions awaiting outbound events.
+  private throwAndClose(error: unknown): void {
+    this.messages$.complete();
+    this.errorInternal$.error(error);
+  }
+
+  // Keeps track of all outbound messages. If the outbound `message` contains a
+  // request or response, registers it with pendingOutboundRequests. If it
+  // contains a request, runs the appropriate callback to generate an inbound
+  // response, and then sends it inbound.
+  private handleOutboundMessage(
+    message: OutboundTypedMessage
+  ): PromiseOr<void, sync> {
+    switch (message.type) {
+      case OutboundMessage.MessageCase.LOG_EVENT:
+        return undefined;
+
+      case OutboundMessage.MessageCase.COMPILE_RESPONSE:
+        this.pendingInboundRequests.resolve(
+          (message.payload as OutboundResponse).getId(),
+          message.type
+        );
+        return undefined;
+
+      case OutboundMessage.MessageCase.IMPORT_REQUEST: {
+        const request = message.payload as OutboundMessage.ImportRequest;
+        const id = request.getId();
+        const type = InboundMessage.MessageCase.IMPORT_RESPONSE;
+        this.pendingOutboundRequests.add(id, type);
+
+        return thenOr(
+          this.outboundRequestHandlers.handleImportRequest(request),
+          response => {
+            this.sendInboundMessage(id, response, type);
+          }
+        );
+      }
+
+      case OutboundMessage.MessageCase.FILE_IMPORT_REQUEST: {
+        const request = message.payload as OutboundMessage.FileImportRequest;
+        const id = request.getId();
+        const type = InboundMessage.MessageCase.FILE_IMPORT_RESPONSE;
+        this.pendingOutboundRequests.add(id, type);
+        return thenOr(
+          this.outboundRequestHandlers.handleFileImportRequest(request),
+          response => {
+            this.sendInboundMessage(id, response, type);
+          }
+        );
+      }
+
+      case OutboundMessage.MessageCase.CANONICALIZE_REQUEST: {
+        const request = message.payload as OutboundMessage.CanonicalizeRequest;
+        const id = request.getId();
+        const type = InboundMessage.MessageCase.CANONICALIZE_RESPONSE;
+        this.pendingOutboundRequests.add(id, type);
+        return thenOr(
+          this.outboundRequestHandlers.handleCanonicalizeRequest(request),
+          response => {
+            this.sendInboundMessage(id, response, type);
+          }
+        );
+      }
+
+      case OutboundMessage.MessageCase.FUNCTION_CALL_REQUEST: {
+        const request = message.payload as OutboundMessage.FunctionCallRequest;
+        const id = request.getId();
+        const type = InboundMessage.MessageCase.FUNCTION_CALL_RESPONSE;
+        this.pendingOutboundRequests.add(id, type);
+        return thenOr(
+          this.outboundRequestHandlers.handleFunctionCallRequest(request),
+          response => {
+            this.sendInboundMessage(id, response, type);
+          }
+        );
+      }
+
+      default:
+        throw Error(`Unknown message type ${message.type}`);
+    }
+  }
+
+  // Sends a `request` of type `requestType` inbound. Returns a promise that
+  // will either resolve with the corresponding outbound response of type
+  // `responseType`, or error if any Protocol Errors were encountered.
+  private handleInboundRequest(
+    request: InboundRequest,
+    requestType: InboundRequestType,
+    responseType: OutboundResponseType,
+    callback: (err: unknown, response: OutboundResponse | undefined) => void
+  ): void {
+    if (this.messages$.isStopped) {
+      callback(new Error('Tried writing to closed dispatcher'), undefined);
+      return;
+    }
+
+    this.messages$
+      .pipe(
+        filter(message => message.type === responseType),
+        map(message => message.payload as OutboundResponse),
+        filter(response => response.getId() === request.getId())
+      )
+      .subscribe({next: response => callback(null, response)});
+
+    this.error$.subscribe({error: error => callback(error, undefined)});
+
+    try {
+      this.sendInboundMessage(
+        this.pendingInboundRequests.nextId,
+        request,
+        requestType
+      );
+    } catch (error) {
+      this.throwAndClose(error);
+    }
+  }
+
+  // Sends a message inbound. Keeps track of all pending inbound requests.
+  private sendInboundMessage(
+    id: number,
+    payload: InboundRequest | InboundResponse,
+    type: InboundRequestType | InboundResponseType
+  ): void {
+    payload.setId(id);
+
+    if (type === InboundMessage.MessageCase.COMPILE_REQUEST) {
+      this.pendingInboundRequests.add(
+        id,
+        OutboundMessage.MessageCase.COMPILE_RESPONSE
+      );
+    } else if (
+      type === InboundMessage.MessageCase.IMPORT_RESPONSE ||
+      type === InboundMessage.MessageCase.FILE_IMPORT_RESPONSE ||
+      type === InboundMessage.MessageCase.CANONICALIZE_RESPONSE ||
+      type === InboundMessage.MessageCase.FUNCTION_CALL_RESPONSE
+    ) {
+      this.pendingOutboundRequests.resolve(id, type);
+    } else {
+      throw Error(`Unknown message type ${type}`);
+    }
+
+    this.writeInboundMessage({
+      payload,
+      type,
+    });
+  }
+}
+
+/**
+ * An interface for the handler callbacks that are passed to `new Dispatcher()`.
+ */
+export interface DispatcherHandlers<sync extends 'sync' | 'async'> {
+  handleImportRequest: (
+    request: OutboundMessage.ImportRequest
+  ) => PromiseOr<InboundMessage.ImportResponse, sync>;
+  handleFileImportRequest: (
+    request: OutboundMessage.FileImportRequest
+  ) => PromiseOr<InboundMessage.FileImportResponse, sync>;
+  handleCanonicalizeRequest: (
+    request: OutboundMessage.CanonicalizeRequest
+  ) => PromiseOr<InboundMessage.CanonicalizeResponse, sync>;
+  handleFunctionCallRequest: (
+    request: OutboundMessage.FunctionCallRequest
+  ) => PromiseOr<InboundMessage.FunctionCallResponse, sync>;
+}

--- a/lib/src/exception.ts
+++ b/lib/src/exception.ts
@@ -1,0 +1,25 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import {Exception as SassException, SourceSpan} from './vendor/sass';
+import {deprotofySourceSpan} from './deprotofy-span';
+
+export class Exception extends Error implements SassException {
+  readonly sassMessage: string;
+  readonly sassStack: string;
+  readonly span: SourceSpan;
+
+  constructor(failure: proto.OutboundMessage.CompileResponse.CompileFailure) {
+    super(failure.getFormatted());
+
+    this.sassMessage = failure.getMessage();
+    this.sassStack = failure.getStackTrace();
+    this.span = deprotofySourceSpan(failure.getSpan()!);
+  }
+
+  toString() {
+    return this.message;
+  }
+}

--- a/lib/src/function-registry.ts
+++ b/lib/src/function-registry.ts
@@ -1,0 +1,125 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {inspect} from 'util';
+
+import * as types from './vendor/sass';
+import * as utils from './utils';
+import {CustomFunction} from './vendor/sass';
+import {
+  InboundMessage,
+  OutboundMessage,
+} from './vendor/embedded-protocol/embedded_sass_pb';
+import {PromiseOr, catchOr, thenOr} from './utils';
+import {Protofier} from './protofier';
+import {Value} from './value';
+
+/**
+ * The next ID to use for a function. The embedded protocol requires that
+ * function IDs be globally unique.
+ */
+let nextFunctionID = 0;
+
+/**
+ * Tracks functions that are defined on the host so that the compiler can
+ * execute them.
+ */
+export class FunctionRegistry<sync extends 'sync' | 'async'> {
+  private readonly functionsByName = new Map<string, CustomFunction<sync>>();
+  private readonly functionsById = new Map<number, CustomFunction<sync>>();
+  private readonly idsByFunction = new Map<CustomFunction<sync>, number>();
+
+  constructor(functionsBySignature?: Record<string, CustomFunction<sync>>) {
+    for (const [signature, fn] of Object.entries(functionsBySignature ?? {})) {
+      const openParen = signature.indexOf('(');
+      if (openParen === -1) {
+        throw new Error(`options.functions: "${signature}" is missing "("`);
+      }
+
+      this.functionsByName.set(signature.substring(0, openParen), fn);
+    }
+  }
+
+  /** Registers `fn` as a function that can be called using the returned ID. */
+  register(fn: CustomFunction<sync>): number {
+    return utils.putIfAbsent(this.idsByFunction, fn, () => {
+      const id = nextFunctionID;
+      nextFunctionID += 1;
+      this.functionsById.set(id, fn);
+      return id;
+    });
+  }
+
+  /**
+   * Returns the function to which `request` refers and returns its response.
+   */
+  call(
+    request: OutboundMessage.FunctionCallRequest
+  ): PromiseOr<InboundMessage.FunctionCallResponse, sync> {
+    const protofier = new Protofier(this);
+    const fn = this.get(request);
+
+    return catchOr(
+      () => {
+        return thenOr(
+          fn(
+            request
+              .getArgumentsList()
+              .map(value => protofier.deprotofy(value) as types.Value)
+          ),
+          result => {
+            if (!(result instanceof Value)) {
+              const name =
+                request.getName().length === 0
+                  ? 'anonymous function'
+                  : `"${request.getName()}"`;
+              throw (
+                `options.functions: ${name} returned non-Value: ` +
+                inspect(result)
+              );
+            }
+
+            const response = new InboundMessage.FunctionCallResponse();
+            response.setSuccess(protofier.protofy(result));
+            response.setAccessedArgumentListsList(
+              protofier.accessedArgumentLists
+            );
+            return response;
+          }
+        );
+      },
+      error => {
+        const response = new InboundMessage.FunctionCallResponse();
+        response.setError(`${error}`);
+        return response;
+      }
+    );
+  }
+
+  /** Returns the function to which `request` refers. */
+  private get(
+    request: OutboundMessage.FunctionCallRequest
+  ): CustomFunction<sync> {
+    if (
+      request.getIdentifierCase() ===
+      OutboundMessage.FunctionCallRequest.IdentifierCase.NAME
+    ) {
+      const fn = this.functionsByName.get(request.getName());
+      if (fn) return fn;
+
+      throw new Error(
+        'Invalid OutboundMessage.FunctionCallRequest: there is no function ' +
+          `named "${request.getName()}"`
+      );
+    } else {
+      const fn = this.functionsById.get(request.getFunctionId());
+      if (fn) return fn;
+
+      throw new Error(
+        'Invalid OutboundMessage.FunctionCallRequest: there is no function ' +
+          `with ID "${request.getFunctionId()}"`
+      );
+    }
+  }
+}

--- a/lib/src/importer-registry.ts
+++ b/lib/src/importer-registry.ts
@@ -1,0 +1,184 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as p from 'path';
+import {URL} from 'url';
+import {inspect} from 'util';
+
+import * as utils from './utils';
+import {FileImporter, Importer, Options} from './vendor/sass';
+import {
+  InboundMessage,
+  OutboundMessage,
+} from './vendor/embedded-protocol/embedded_sass_pb';
+import {catchOr, thenOr, PromiseOr} from './utils';
+
+/**
+ * A registry of importers defined in the host that can be invoked by the
+ * compiler.
+ */
+export class ImporterRegistry<sync extends 'sync' | 'async'> {
+  /** Protocol buffer representations of the registered importers. */
+  readonly importers: InboundMessage.CompileRequest.Importer[];
+
+  /** A map from importer IDs to their corresponding importers. */
+  private readonly importersById = new Map<number, Importer<sync>>();
+
+  /** A map from file importer IDs to their corresponding importers. */
+  private readonly fileImportersById = new Map<number, FileImporter<sync>>();
+
+  /** The next ID to use for an importer. */
+  private id = 0;
+
+  constructor(options?: Options<sync>) {
+    this.importers = (options?.importers ?? [])
+      .map(importer => this.register(importer))
+      .concat(
+        (options?.loadPaths ?? []).map(path => {
+          const proto = new InboundMessage.CompileRequest.Importer();
+          proto.setPath(p.resolve(path));
+          return proto;
+        })
+      );
+  }
+
+  /** Converts an importer to a proto without adding it to `this.importers`. */
+  register(
+    importer: Importer<sync> | FileImporter<sync>
+  ): InboundMessage.CompileRequest.Importer {
+    const proto = new InboundMessage.CompileRequest.Importer();
+    if ('canonicalize' in importer) {
+      if ('findFileUrl' in importer) {
+        throw new Error(
+          'Importer may not contain both canonicalize() and findFileUrl(): ' +
+            inspect(importer)
+        );
+      }
+
+      proto.setImporterId(this.id);
+      this.importersById.set(this.id, importer);
+    } else {
+      proto.setFileImporterId(this.id);
+      this.fileImportersById.set(this.id, importer);
+    }
+    this.id += 1;
+    return proto;
+  }
+
+  /** Handles a canonicalization request. */
+  canonicalize(
+    request: OutboundMessage.CanonicalizeRequest
+  ): PromiseOr<InboundMessage.CanonicalizeResponse, sync> {
+    const importer = this.importersById.get(request.getImporterId());
+    if (!importer) {
+      throw utils.compilerError('Unknown CanonicalizeRequest.importer_id');
+    }
+
+    return catchOr(
+      () => {
+        return thenOr(
+          importer.canonicalize(request.getUrl(), {
+            fromImport: request.getFromImport(),
+          }),
+          url => {
+            const proto = new InboundMessage.CanonicalizeResponse();
+            if (url !== null) proto.setUrl(url.toString());
+            return proto;
+          }
+        );
+      },
+      error => {
+        const proto = new InboundMessage.CanonicalizeResponse();
+        proto.setError(`${error}`);
+        return proto;
+      }
+    );
+  }
+
+  /** Handles an import request. */
+  import(
+    request: OutboundMessage.ImportRequest
+  ): PromiseOr<InboundMessage.ImportResponse, sync> {
+    const importer = this.importersById.get(request.getImporterId());
+    if (!importer) {
+      throw utils.compilerError('Unknown ImportRequest.importer_id');
+    }
+
+    return catchOr(
+      () => {
+        return thenOr(importer.load(new URL(request.getUrl())), result => {
+          const proto = new InboundMessage.ImportResponse();
+          if (result) {
+            if (typeof result.contents !== 'string') {
+              throw Error(
+                `Invalid argument (contents): must be a string but was: ${
+                  (result.contents as {}).constructor.name
+                }`
+              );
+            }
+
+            if (result.sourceMapUrl && !result.sourceMapUrl.protocol) {
+              throw Error(
+                'Invalid argument (sourceMapUrl): must be absolute but was: ' +
+                  result.sourceMapUrl
+              );
+            }
+
+            const success = new InboundMessage.ImportResponse.ImportSuccess();
+            success.setContents(result.contents);
+            success.setSyntax(utils.protofySyntax(result.syntax));
+            if (result.sourceMapUrl) {
+              success.setSourceMapUrl(result.sourceMapUrl.toString());
+            }
+            proto.setSuccess(success);
+          }
+          return proto;
+        });
+      },
+      error => {
+        const proto = new InboundMessage.ImportResponse();
+        proto.setError(`${error}`);
+        return proto;
+      }
+    );
+  }
+
+  /** Handles a file import request. */
+  fileImport(
+    request: OutboundMessage.FileImportRequest
+  ): PromiseOr<InboundMessage.FileImportResponse, sync> {
+    const importer = this.fileImportersById.get(request.getImporterId());
+    if (!importer) {
+      throw utils.compilerError('Unknown FileImportRequest.importer_id');
+    }
+
+    return catchOr(
+      () => {
+        return thenOr(
+          importer.findFileUrl(request.getUrl(), {
+            fromImport: request.getFromImport(),
+          }),
+          url => {
+            const proto = new InboundMessage.FileImportResponse();
+            if (url) {
+              if (url.protocol !== 'file:') {
+                throw (
+                  `FileImporter ${inspect(importer)} returned non-file: URL ` +
+                  +`"${url}" for URL "${request.getUrl()}".`
+                );
+              }
+              proto.setFileUrl(url.toString());
+            }
+            return proto;
+          }
+        );
+      },
+      error => {
+        const proto = new InboundMessage.FileImportResponse();
+        proto.setError(`${error}`);
+        return proto;
+      }
+    );
+  }
+}

--- a/lib/src/legacy/importer.ts
+++ b/lib/src/legacy/importer.ts
@@ -1,0 +1,315 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {strict as assert} from 'assert';
+import {pathToFileURL, URL as NodeURL} from 'url';
+import * as fs from 'fs';
+import * as p from 'path';
+import * as util from 'util';
+
+import {resolvePath} from './resolve-path';
+import {
+  fileUrlToPathCrossPlatform,
+  isErrnoException,
+  thenOr,
+  PromiseOr,
+  SyncBoolean,
+} from '../utils';
+import {
+  Importer,
+  ImporterResult,
+  LegacyAsyncImporter,
+  LegacyImporter,
+  LegacyImporterResult,
+  LegacyImporterThis,
+  LegacyPluginThis,
+  LegacySyncImporter,
+} from '../vendor/sass';
+
+/**
+ * A special URL protocol we use to signal when a stylesheet has finished
+ * loading. This allows us to determine which stylesheet is "current" when
+ * resolving a new load, which in turn allows us to pass in an accurate `prev`
+ * parameter to the legacy callback.
+ */
+export const endOfLoadProtocol = 'sass-embedded-legacy-load-done:';
+
+/**
+ * The URL protocol to use for URLs canonicalized using `LegacyImporterWrapper`.
+ */
+export const legacyImporterProtocol = 'legacy-importer:';
+
+// A count of `endOfLoadProtocol` imports that have been generated. Each one
+// must be a different URL to ensure that the importer results aren't cached.
+let endOfLoadCount = 0;
+
+// The interface for previous URLs that were passed to
+// `LegacyImporterWrapper.callbacks`.
+interface PreviousUrl {
+  // The URL itself. This is actually an absolute path if `path` is true.
+  url: string;
+
+  // Whether `url` is an absolute path.
+  path: boolean;
+}
+
+/**
+ * A wrapper around a `LegacyImporter` callback that exposes it as a new-API
+ * `Importer`.
+ */
+export class LegacyImporterWrapper<sync extends 'sync' | 'async'>
+  implements Importer<sync>
+{
+  // A stack of previous URLs passed to `this.callbacks`.
+  private readonly prev: PreviousUrl[] = [];
+
+  // The `contents` field returned by the last successful invocation of
+  // `this.callbacks`, if it returned one.
+  private lastContents: string | undefined;
+
+  // Whether we're expecting the next call to `canonicalize()` to be a relative
+  // load. The legacy importer API doesn't handle these loads in the same way as
+  // the modern API, so we always return `null` in this case.
+  private expectingRelativeLoad = true;
+
+  constructor(
+    private readonly self: LegacyPluginThis,
+    private readonly callbacks: Array<LegacyImporter<sync>>,
+    private readonly loadPaths: string[],
+    initialPrev: string,
+    private readonly sync: SyncBoolean<sync>
+  ) {
+    const path = initialPrev !== 'stdin';
+    this.prev.push({url: path ? p.resolve(initialPrev) : 'stdin', path});
+  }
+
+  canonicalize(
+    url: string,
+    options: {fromImport: boolean}
+  ): PromiseOr<URL | null, sync> {
+    if (url.startsWith(endOfLoadProtocol)) return new URL(url);
+
+    // Since there's only ever one modern importer in legacy mode, we can be
+    // sure that all normal loads are preceded by exactly one relative load.
+    if (this.expectingRelativeLoad) {
+      if (url.startsWith('file:')) {
+        let resolved: string | null = null;
+
+        try {
+          const path = fileUrlToPathCrossPlatform(url);
+          resolved = resolvePath(path, options.fromImport);
+        } catch (error: unknown) {
+          if (
+            error instanceof TypeError &&
+            isErrnoException(error) &&
+            (error.code === 'ERR_INVALID_URL' ||
+              error.code === 'ERR_INVALID_FILE_URL_PATH')
+          ) {
+            // It's possible for `url` to represent an invalid path for the
+            // current platform. For example, `@import "/foo/bar/baz"` will
+            // resolve to `file:///foo/bar/baz` which is an invalid URL on
+            // Windows. In that case, we treat it as though the file doesn't
+            // exist so that the user's custom importer can still handle the
+            // URL.
+          } else {
+            throw error;
+          }
+        }
+
+        if (resolved !== null) {
+          this.prev.push({url: resolved, path: true});
+          return pathToFileURL(resolved);
+        }
+      }
+
+      this.expectingRelativeLoad = false;
+      return null;
+    } else {
+      this.expectingRelativeLoad = true;
+    }
+
+    const prev = this.prev[this.prev.length - 1];
+    return thenOr(
+      thenOr(this.invokeCallbacks(url, prev.url, options), result => {
+        if (result instanceof Error) throw result;
+        if (result === null) return null;
+
+        if (typeof result !== 'object') {
+          throw (
+            'Expected importer to return an object, got ' +
+            `${util.inspect(result)}.`
+          );
+        }
+
+        if ('contents' in result || !('file' in result)) {
+          this.lastContents = result.contents ?? '';
+
+          if ('file' in result) {
+            return new URL(
+              legacyImporterProtocol +
+                encodeURI((result as {file: string}).file)
+            );
+          } else if (/^[A-Za-z+.-]+:/.test(url)) {
+            return new URL(url);
+          } else {
+            return new URL(legacyImporterProtocol + encodeURI(url));
+          }
+        } else {
+          if (p.isAbsolute(result.file)) {
+            const resolved = resolvePath(result.file, options.fromImport);
+            return resolved ? pathToFileURL(resolved) : null;
+          }
+
+          const prefixes = [...this.loadPaths, '.'];
+          if (prev.path) prefixes.unshift(p.dirname(prev.url));
+
+          for (const prefix of prefixes) {
+            const resolved = resolvePath(
+              p.join(prefix, result.file),
+              options.fromImport
+            );
+            if (resolved !== null) return pathToFileURL(resolved);
+          }
+          return null;
+        }
+      }),
+      result => {
+        if (result !== null) {
+          const path = result.protocol === 'file:';
+          this.prev.push({
+            url: path ? fileUrlToPathCrossPlatform(result as NodeURL) : url,
+            path,
+          });
+          return result;
+        } else {
+          for (const loadPath of this.loadPaths) {
+            const resolved = resolvePath(
+              p.join(loadPath, url),
+              options.fromImport
+            );
+            if (resolved !== null) return pathToFileURL(resolved);
+          }
+          return null;
+        }
+      }
+    );
+  }
+
+  load(canonicalUrl: URL): ImporterResult | null {
+    if (canonicalUrl.protocol === endOfLoadProtocol) {
+      this.prev.pop();
+      return {
+        contents: '',
+        syntax: 'scss',
+        sourceMapUrl: new URL(endOfLoadProtocol),
+      };
+    }
+
+    if (canonicalUrl.protocol === 'file:') {
+      const syntax = canonicalUrl.pathname.endsWith('.sass')
+        ? 'indented'
+        : canonicalUrl.pathname.endsWith('.css')
+        ? 'css'
+        : 'scss';
+
+      let contents =
+        this.lastContents ??
+        fs.readFileSync(
+          fileUrlToPathCrossPlatform(canonicalUrl as NodeURL),
+          'utf-8'
+        );
+      this.lastContents = undefined;
+      if (syntax === 'scss') {
+        contents += this.endOfLoadImport;
+      } else if (syntax === 'indented') {
+        contents += `\n@import "${endOfLoadProtocol}${endOfLoadCount++}"`;
+      } else {
+        this.prev.pop();
+      }
+
+      return {contents, syntax, sourceMapUrl: canonicalUrl};
+    }
+
+    const lastContents = this.lastContents;
+    assert.notEqual(lastContents, undefined);
+    this.lastContents = undefined;
+    return {
+      contents: lastContents + this.endOfLoadImport,
+      syntax: 'scss',
+      sourceMapUrl: canonicalUrl,
+    };
+  }
+
+  // Invokes each callback in `this.callbacks` until one returns a non-null
+  // `LegacyImporterResult`, then returns that result. Returns `null` if all
+  // callbacks return `null`.
+  private invokeCallbacks(
+    url: string,
+    prev: string,
+    {fromImport}: {fromImport: boolean}
+  ): PromiseOr<LegacyImporterResult, sync> {
+    assert(this.callbacks.length > 0);
+
+    const self: LegacyImporterThis = {...this.self, fromImport};
+    self.options = {...self.options, context: self};
+
+    const invokeNthCallback = (
+      n: number
+    ): PromiseOr<LegacyImporterResult, sync> =>
+      thenOr(
+        this.invokeCallback(this.callbacks[n], self, url, prev),
+        result => {
+          if (result === null) {
+            if (n === this.callbacks.length - 1) return null;
+            return invokeNthCallback(n + 1);
+          }
+          if (
+            'contents' in result &&
+            result.contents &&
+            typeof result.contents !== 'string'
+          ) {
+            throw new Error(
+              `Invalid argument (contents): must be a string but was: ${
+                (result.contents as {}).constructor.name
+              }`
+            );
+          }
+          return result;
+        }
+      );
+
+    return invokeNthCallback(0);
+  }
+
+  // Invokes `callback` and converts its return value into a `PromiseOr`.
+  private invokeCallback(
+    callback: LegacyImporter<sync>,
+    self: LegacyImporterThis,
+    url: string,
+    prev: string
+  ): PromiseOr<LegacyImporterResult, sync> {
+    if (this.sync) {
+      return (callback as LegacySyncImporter).call(self, url, prev);
+    }
+
+    return new Promise(resolve => {
+      // The cast here is necesary to work around microsoft/TypeScript#33815.
+      const syncResult = (callback as LegacyAsyncImporter).call(
+        self,
+        url,
+        prev,
+        resolve
+      );
+
+      if (syncResult !== undefined) resolve(syncResult);
+    }) as PromiseOr<LegacyImporterResult, sync>;
+  }
+
+  // The `@import` statement to inject after the contents of files to ensure
+  // that we know when a load has completed so we can pass the correct `prev`
+  // argument to callbacks.
+  private get endOfLoadImport() {
+    return `\n;@import "${endOfLoadProtocol}${endOfLoadCount++}";`;
+  }
+}

--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -1,0 +1,349 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as fs from 'fs';
+import * as p from 'path';
+import {URL, pathToFileURL} from 'url';
+
+import {Exception} from '../exception';
+import {
+  compile,
+  compileAsync,
+  compileString,
+  compileStringAsync,
+} from '../compile';
+import {
+  fileUrlToPathCrossPlatform,
+  isNullOrUndefined,
+  pathToUrlString,
+  withoutExtension,
+  SyncBoolean,
+} from '../utils';
+import {
+  CompileResult,
+  CustomFunction,
+  LegacyException,
+  LegacyOptions,
+  LegacyPluginThis,
+  LegacyResult,
+  LegacySharedOptions,
+  LegacyStringOptions,
+  Options,
+  StringOptions,
+} from '../vendor/sass';
+import {wrapFunction} from './value/wrap';
+import {
+  endOfLoadProtocol,
+  legacyImporterProtocol,
+  LegacyImporterWrapper,
+} from './importer';
+
+export function render(
+  options: LegacyOptions<'async'>,
+  callback: (error?: LegacyException, result?: LegacyResult) => void
+): void {
+  try {
+    options = adjustOptions(options);
+
+    const start = Date.now();
+    const compileSass = isStringOptions(options)
+      ? compileStringAsync(options.data, convertStringOptions(options, false))
+      : compileAsync(options.file, convertOptions(options, false));
+
+    compileSass.then(
+      result => callback(undefined, newLegacyResult(options, start, result)),
+      error => callback(newLegacyException(error))
+    );
+  } catch (error) {
+    if (error instanceof Error) callback(newLegacyException(error));
+    throw error;
+  }
+}
+
+export function renderSync(options: LegacyOptions<'sync'>): LegacyResult {
+  const start = Date.now();
+  try {
+    options = adjustOptions(options);
+    const result = isStringOptions(options)
+      ? compileString(options.data, convertStringOptions(options, true))
+      : compile(options.file, convertOptions(options, true));
+    return newLegacyResult(options, start, result);
+  } catch (error: unknown) {
+    throw newLegacyException(error as Error);
+  }
+}
+
+// Does some initial adjustments of `options` to make it easier to convert pass
+// to the new API.
+function adjustOptions<sync extends 'sync' | 'async'>(
+  options: LegacyOptions<sync>
+): LegacyOptions<sync> {
+  if (!('file' in options && options.file) && !('data' in options)) {
+    throw new Error('Either options.data or options.file must be set.');
+  }
+
+  if (
+    !isStringOptions(options) &&
+    // The `indentedSyntax` option takes precedence over the file extension in the
+    // legacy API, but the new API doesn't have a `syntax` option for a file path.
+    // Instead, we eagerly load the entrypoint into memory and treat it like a
+    // string source.
+    ((options as unknown as LegacyStringOptions<sync>).indentedSyntax !==
+      undefined ||
+      options.importer)
+  ) {
+    return {
+      ...options,
+      data: fs.readFileSync(options.file, 'utf8'),
+      indentedSyntax: !!(options as unknown as LegacyStringOptions<sync>)
+        .indentedSyntax,
+    };
+  } else {
+    return options;
+  }
+}
+
+// Returns whether `options` is a `LegacyStringOptions`.
+function isStringOptions<sync extends 'sync' | 'async'>(
+  options: LegacyOptions<sync>
+): options is LegacyStringOptions<sync> {
+  return 'data' in options;
+}
+
+// Converts `LegacyOptions` into new API `Options`.
+function convertOptions<sync extends 'sync' | 'async'>(
+  options: LegacyOptions<sync>,
+  sync: SyncBoolean<sync>
+): Options<sync> {
+  if (
+    'outputStyle' in options &&
+    options.outputStyle !== 'compressed' &&
+    options.outputStyle !== 'expanded'
+  ) {
+    throw new Error(`Unknown output style: "${options.outputStyle}"`);
+  }
+
+  const self = pluginThis(options);
+  const functions: Record<string, CustomFunction<sync>> = {};
+  for (let [signature, callback] of Object.entries(options.functions ?? {})) {
+    // The legacy API allows signatures without parentheses but the modern API
+    // does not.
+    if (!signature.includes('(')) signature += '()';
+
+    functions[signature] = wrapFunction(self, callback, sync);
+  }
+
+  const importers =
+    options.importer &&
+    (!(options.importer instanceof Array) || options.importer.length > 0)
+      ? [
+          new LegacyImporterWrapper(
+            self,
+            options.importer instanceof Array
+              ? options.importer
+              : [options.importer],
+            options.includePaths ?? [],
+            options.file ?? 'stdin',
+            sync
+          ),
+        ]
+      : undefined;
+
+  return {
+    functions,
+    importers,
+    sourceMap: wasSourceMapRequested(options),
+    sourceMapIncludeSources: options.sourceMapContents,
+    loadPaths: importers ? undefined : options.includePaths,
+    style: options.outputStyle as 'compressed' | 'expanded' | undefined,
+    quietDeps: options.quietDeps,
+    verbose: options.verbose,
+    charset: options.charset,
+    logger: options.logger,
+  };
+}
+
+// Converts `LegacyStringOptions` into new API `StringOptions`.
+function convertStringOptions<sync extends 'sync' | 'async'>(
+  options: LegacyStringOptions<sync>,
+  sync: SyncBoolean<sync>
+): StringOptions<sync> {
+  const modernOptions = convertOptions(options, sync);
+
+  return {
+    ...modernOptions,
+    url: options.file
+      ? pathToFileURL(options.file)
+      : new URL(legacyImporterProtocol),
+    importer: modernOptions.importers ? modernOptions.importers[0] : undefined,
+    syntax: options.indentedSyntax ? 'indented' : 'scss',
+  };
+}
+
+// Determines whether a sourceMap was requested by the call to `render()`.
+function wasSourceMapRequested(
+  options: LegacySharedOptions<'sync' | 'async'>
+): boolean {
+  return (
+    typeof options.sourceMap === 'string' ||
+    (options.sourceMap === true && !!options.outFile)
+  );
+}
+
+// Creates the `this` value that's used for callbacks.
+function pluginThis(
+  options: LegacyOptions<'sync' | 'async'>
+): LegacyPluginThis {
+  const pluginThis: LegacyPluginThis = {
+    options: {
+      context: undefined as unknown as LegacyPluginThis,
+      file: options.file,
+      data: options.data,
+      includePaths: [process.cwd(), ...(options.includePaths ?? [])].join(
+        p.delimiter
+      ),
+      precision: 10,
+      style: 1,
+      indentType: 0,
+      indentWidth: 2,
+      linefeed: '\n',
+      result: {
+        stats: {
+          start: Date.now(),
+          entry: options.file ?? 'data',
+        },
+      },
+    },
+  };
+  pluginThis.options.context = pluginThis;
+  return pluginThis;
+}
+
+// Transforms the compilation result into an object that mimics the Node Sass
+// API format.
+function newLegacyResult(
+  options: LegacyOptions<'sync' | 'async'>,
+  start: number,
+  result: CompileResult
+): LegacyResult {
+  const end = Date.now();
+
+  let css = result.css;
+  let sourceMapBytes: Buffer | undefined;
+  if (result.sourceMap) {
+    const sourceMap = result.sourceMap;
+    sourceMap.sourceRoot = options.sourceMapRoot ?? '';
+
+    const sourceMapPath =
+      typeof options.sourceMap === 'string'
+        ? (options.sourceMap as string)
+        : options.outFile + '.map';
+    const sourceMapDir = p.dirname(sourceMapPath);
+
+    if (options.outFile) {
+      sourceMap.file = pathToUrlString(
+        p.relative(sourceMapDir, options.outFile)
+      );
+    } else if (options.file) {
+      sourceMap.file = pathToUrlString(withoutExtension(options.file) + '.css');
+    } else {
+      sourceMap.file = 'stdin.css';
+    }
+
+    sourceMap.sources = sourceMap.sources
+      .filter(source => !source.startsWith(endOfLoadProtocol))
+      .map(source => {
+        if (source.startsWith('file://')) {
+          return pathToUrlString(
+            p.relative(sourceMapDir, fileUrlToPathCrossPlatform(source))
+          );
+        } else if (source.startsWith(legacyImporterProtocol)) {
+          return source.substring(legacyImporterProtocol.length);
+        } else if (source.startsWith('data:')) {
+          return 'stdin';
+        } else {
+          return source;
+        }
+      });
+
+    sourceMapBytes = Buffer.from(JSON.stringify(sourceMap));
+
+    if (!options.omitSourceMapUrl) {
+      let url;
+      if (options.sourceMapEmbed) {
+        url = `data:application/json;base64,${sourceMapBytes.toString(
+          'base64'
+        )}`;
+      } else if (options.outFile) {
+        url = pathToUrlString(
+          p.relative(p.dirname(options.outFile), sourceMapPath)
+        );
+      } else {
+        url = pathToUrlString(sourceMapPath);
+      }
+      css += `\n\n/*# sourceMappingURL=${url} */`;
+    }
+  }
+
+  return {
+    css: Buffer.from(css),
+    map: sourceMapBytes,
+    stats: {
+      entry: options.file ?? 'data',
+      start,
+      end,
+      duration: end - start,
+      includedFiles: result.loadedUrls
+        .filter(url => url.protocol !== endOfLoadProtocol)
+        .map(url => {
+          if (url.protocol === 'file:') {
+            return fileUrlToPathCrossPlatform(url as URL);
+          } else if (url.protocol === legacyImporterProtocol) {
+            return decodeURI(url.pathname);
+          } else {
+            return url.toString();
+          }
+        }),
+    },
+  };
+}
+
+// Decorates an Error with additional fields so that it behaves like a Node Sass
+// error.
+function newLegacyException(error: Error): LegacyException {
+  if (!(error instanceof Exception)) {
+    return Object.assign(error, {
+      formatted: error.toString(),
+      status: 3,
+    });
+  }
+
+  let file: string;
+  if (!error.span?.url) {
+    file = 'stdin';
+  } else if (error.span.url.protocol === 'file:') {
+    // We have to cast to Node's URL type here because the specified type is the
+    // standard URL type which is slightly less featureful. `fileURLToPath()`
+    // does work with standard URL objects in practice, but we know that we
+    // generate Node URLs here regardless.
+    file = fileUrlToPathCrossPlatform(error.span.url as URL);
+  } else {
+    file = error.span.url.toString();
+  }
+
+  return Object.assign(new Error(), {
+    status: 1,
+    message: error.toString().replace(/^Error: /, ''),
+    formatted: error.toString(),
+    toString: () => error.toString(),
+    stack: error.stack,
+    line: isNullOrUndefined(error.span?.start.line)
+      ? undefined
+      : error.span!.start.line + 1,
+    column: isNullOrUndefined(error.span?.start.column)
+      ? undefined
+      : error.span!.start.column + 1,
+    file,
+  });
+}

--- a/lib/src/legacy/resolve-path.ts
+++ b/lib/src/legacy/resolve-path.ts
@@ -1,0 +1,107 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as fs from 'fs';
+import * as p from 'path';
+
+/**
+ * Resolves a path using the same logic as the filesystem importer.
+ *
+ * This tries to fill in extensions and partial prefixes and check for a
+ * directory default. If no file can be found, it returns `null`.
+ */
+export function resolvePath(path: string, fromImport: boolean): string | null {
+  const extension = p.extname(path);
+  if (extension === '.sass' || extension === '.scss' || extension === '.css') {
+    return (
+      (fromImport
+        ? exactlyOne(tryPath(`${withoutExtension(path)}.import${extension}`))
+        : null) ?? exactlyOne(tryPath(path))
+    );
+  }
+
+  return (
+    (fromImport ? exactlyOne(tryPathWithExtensions(`${path}.import`)) : null) ??
+    exactlyOne(tryPathWithExtensions(path)) ??
+    tryPathAsDirectory(path, fromImport)
+  );
+}
+
+// Like `tryPath`, but checks `.sass`, `.scss`, and `.css` extensions.
+function tryPathWithExtensions(path: string): string[] {
+  const result = [...tryPath(path + '.sass'), ...tryPath(path + '.scss')];
+  return result.length > 0 ? result : tryPath(path + '.css');
+}
+
+// Returns the `path` and/or the partial with the same name, if either or both
+// exists. If neither exists, returns an empty list.
+function tryPath(path: string): string[] {
+  const partial = p.join(p.dirname(path), `_${p.basename(path)}`);
+  const result: string[] = [];
+  if (fileExists(partial)) result.push(partial);
+  if (fileExists(path)) result.push(path);
+  return result;
+}
+
+// Returns the resolved index file for `path` if `path` is a directory and the
+// index file exists. Otherwise, returns `null`.
+function tryPathAsDirectory(path: string, fromImport: boolean): string | null {
+  if (!dirExists(path)) return null;
+
+  return (
+    (fromImport
+      ? exactlyOne(tryPathWithExtensions(p.join(path, 'index.import')))
+      : null) ?? exactlyOne(tryPathWithExtensions(p.join(path, 'index')))
+  );
+}
+
+// If `paths` contains exactly one path, returns that path. If it contains no
+// paths, returns `null`. If it contains more than one, throws an exception.
+function exactlyOne(paths: string[]): string | null {
+  if (paths.length === 0) return null;
+  if (paths.length === 1) return paths[0];
+
+  throw new Error(
+    "It's not clear which file to import. Found:\n" +
+      paths.map(path => '  ' + path).join('\n')
+  );
+}
+
+// Returns whether or not a file (not a directory) exists at `path`.
+function fileExists(path: string): boolean {
+  // `existsSync()` is faster than `statSync()`, but it doesn't clarify whether
+  // the entity in question is a file or a directory. Since false negatives are
+  // much more common than false positives, it works out in our favor to check
+  // this first.
+  if (!fs.existsSync(path)) return false;
+
+  try {
+    return fs.statSync(path).isFile();
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+// Returns whether or not a directory (not a file) exists at `path`.
+function dirExists(path: string): boolean {
+  // `existsSync()` is faster than `statSync()`, but it doesn't clarify whether
+  // the entity in question is a file or a directory. Since false negatives are
+  // much more common than false positives, it works out in our favor to check
+  // this first.
+  if (!fs.existsSync(path)) return false;
+
+  try {
+    return fs.statSync(path).isDirectory();
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+// Returns `path` without its file extension.
+function withoutExtension(path: string): string {
+  const extension = p.extname(path);
+  return path.substring(0, path.length - extension.length);
+}

--- a/lib/src/legacy/value/base.ts
+++ b/lib/src/legacy/value/base.ts
@@ -1,0 +1,13 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {Value} from '../../value';
+
+/**
+ * A base class for legacy value types. A shared base class makes it easier to
+ * detect legacy values and extract their inner value objects.
+ */
+export class LegacyValueBase<T extends Value> {
+  constructor(public inner: T) {}
+}

--- a/lib/src/legacy/value/color.ts
+++ b/lib/src/legacy/value/color.ts
@@ -1,0 +1,83 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {SassColor} from '../../value/color';
+import {LegacyValueBase} from './base';
+
+export class LegacyColor extends LegacyValueBase<SassColor> {
+  constructor(red: number, green: number, blue: number, alpha?: number);
+  constructor(argb: number);
+  constructor(inner: SassColor);
+
+  constructor(
+    redOrArgb: number | SassColor,
+    green?: number,
+    blue?: number,
+    alpha?: number
+  ) {
+    if (redOrArgb instanceof SassColor) {
+      super(redOrArgb);
+      return;
+    }
+
+    let red: number;
+    if (!green || !blue) {
+      const argb = redOrArgb as number;
+      alpha = (argb >> 24) / 0xff;
+      red = (argb >> 16) % 0x100;
+      green = (argb >> 8) % 0x100;
+      blue = argb % 0x100;
+    } else {
+      red = redOrArgb!;
+    }
+
+    super(
+      new SassColor({
+        red: clamp(red, 0, 255),
+        green: clamp(green as number, 0, 255),
+        blue: clamp(blue as number, 0, 255),
+        alpha: alpha ? clamp(alpha, 0, 1) : 1,
+      })
+    );
+  }
+
+  getR(): number {
+    return this.inner.red;
+  }
+
+  setR(value: number): void {
+    this.inner = this.inner.change({red: clamp(value, 0, 255)});
+  }
+
+  getG(): number {
+    return this.inner.green;
+  }
+
+  setG(value: number): void {
+    this.inner = this.inner.change({green: clamp(value, 0, 255)});
+  }
+
+  getB(): number {
+    return this.inner.blue;
+  }
+
+  setB(value: number): void {
+    this.inner = this.inner.change({blue: clamp(value, 0, 255)});
+  }
+
+  getA(): number {
+    return this.inner.alpha;
+  }
+
+  setA(value: number): void {
+    this.inner = this.inner.change({alpha: clamp(value, 0, 1)});
+  }
+}
+
+Object.defineProperty(LegacyColor, 'name', {value: 'sass.types.Color'});
+
+// Returns `number` clamped to between `min` and `max`.
+function clamp(num: number, min: number, max: number): number {
+  return Math.min(Math.max(num, min), max);
+}

--- a/lib/src/legacy/value/index.ts
+++ b/lib/src/legacy/value/index.ts
@@ -1,0 +1,22 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {SassBooleanInternal} from '../../value/boolean';
+import {SassNull} from '../../value/null';
+import {LegacyColor} from './color';
+import {LegacyList} from './list';
+import {LegacyMap} from './map';
+import {LegacyNumber} from './number';
+import {LegacyString} from './string';
+
+export const Boolean = SassBooleanInternal;
+export const Color = LegacyColor;
+export const List = LegacyList;
+export const Map = LegacyMap;
+export const Null = SassNull;
+export const Number = LegacyNumber;
+export const String = LegacyString;
+
+// For the `sass.types.Error` object, we just re-export the native Error class.
+export const Error = global.Error;

--- a/lib/src/legacy/value/list.ts
+++ b/lib/src/legacy/value/list.ts
@@ -1,0 +1,65 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {LegacyValueBase} from './base';
+import {LegacyValue} from '../../vendor/sass';
+import {SassList} from '../../value/list';
+import {sassNull} from '../../value/null';
+import {unwrapValue, wrapValue} from './wrap';
+
+export class LegacyList extends LegacyValueBase<SassList> {
+  constructor(length: number, commaSeparator?: boolean);
+  constructor(inner: SassList);
+
+  constructor(lengthOrInner: number | SassList, commaSeparator?: boolean) {
+    if (lengthOrInner instanceof SassList) {
+      super(lengthOrInner);
+      return;
+    }
+
+    super(
+      new SassList(new Array(lengthOrInner).fill(sassNull), {
+        separator: commaSeparator === false ? ' ' : ',',
+      })
+    );
+  }
+
+  getValue(index: number): LegacyValue | undefined {
+    const length = this.inner.asList.size;
+    if (index < 0 || index >= length) {
+      throw new Error(
+        `Invalid index ${index}, must be between 0 and ${length}`
+      );
+    }
+    const value = this.inner.get(index);
+    return value ? wrapValue(value) : undefined;
+  }
+
+  setValue(index: number, value: LegacyValue): void {
+    this.inner = new SassList(
+      this.inner.asList.set(index, unwrapValue(value)),
+      {
+        separator: this.inner.separator,
+        brackets: this.inner.hasBrackets,
+      }
+    );
+  }
+
+  getSeparator(): boolean {
+    return this.inner.separator === ',';
+  }
+
+  setSeparator(isComma: boolean): void {
+    this.inner = new SassList(this.inner.asList, {
+      separator: isComma ? ',' : ' ',
+      brackets: this.inner.hasBrackets,
+    });
+  }
+
+  getLength(): number {
+    return this.inner.asList.size;
+  }
+}
+
+Object.defineProperty(LegacyList, 'name', {value: 'sass.types.List'});

--- a/lib/src/legacy/value/map.ts
+++ b/lib/src/legacy/value/map.ts
@@ -1,0 +1,98 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {OrderedMap} from 'immutable';
+
+import {LegacyValueBase} from './base';
+import {LegacyValue} from '../../vendor/sass';
+import {SassMap} from '../../value/map';
+import {SassNumber} from '../../value/number';
+import {Value} from '../../value';
+import {sassNull} from '../../value/null';
+import {unwrapValue, wrapValue} from './wrap';
+
+export class LegacyMap extends LegacyValueBase<SassMap> {
+  constructor(lengthOrInner: number | SassMap) {
+    if (lengthOrInner instanceof SassMap) {
+      super(lengthOrInner);
+      return;
+    }
+
+    super(
+      new SassMap(
+        OrderedMap(
+          Array.from({length: lengthOrInner}, (_, i) => [
+            new SassNumber(i),
+            sassNull,
+          ])
+        )
+      )
+    );
+  }
+
+  getValue(index: number): LegacyValue {
+    const value = this.inner.contents.valueSeq().get(index);
+    if (index < 0 || !value) {
+      throw new Error(
+        `Invalid index ${index}, must be between 0 and ` +
+          this.inner.contents.size
+      );
+    }
+
+    return wrapValue(value);
+  }
+
+  setValue(index: number, value: LegacyValue): void {
+    this.inner = new SassMap(
+      this.inner.contents.set(this.getUnwrappedKey(index), unwrapValue(value))
+    );
+  }
+
+  getKey(index: number): LegacyValue {
+    return wrapValue(this.getUnwrappedKey(index));
+  }
+
+  // Like `getKey()`, but returns the unwrapped non-legacy value.
+  private getUnwrappedKey(index: number): Value {
+    const key = this.inner.contents.keySeq().get(index);
+    if (index >= 0 && key) return key;
+    throw new Error(
+      `Invalid index ${index}, must be between 0 and ` +
+        this.inner.contents.size
+    );
+  }
+
+  setKey(index: number, key: LegacyValue): void {
+    const oldMap = this.inner.contents;
+    if (index < 0 || index >= oldMap.size) {
+      throw new Error(
+        `Invalid index ${index}, must be between 0 and ${oldMap.size}`
+      );
+    }
+
+    const newKey = unwrapValue(key);
+    const newMap = OrderedMap<Value, Value>().asMutable();
+
+    let i = 0;
+    for (const [oldKey, oldValue] of oldMap.entries()) {
+      if (i === index) {
+        newMap.set(newKey, oldValue);
+      } else {
+        if (newKey.equals(oldKey)) {
+          throw new Error(`${key} is already in the map`);
+        }
+        newMap.set(oldKey, oldValue);
+      }
+      i++;
+    }
+
+    this.inner = new SassMap(newMap.asImmutable());
+  }
+
+  getLength(): number {
+    return this.inner.contents.size;
+  }
+}
+
+Object.defineProperty(LegacyMap, 'name', {value: 'sass.types.Map'});

--- a/lib/src/legacy/value/number.ts
+++ b/lib/src/legacy/value/number.ts
@@ -1,0 +1,70 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {SassNumber} from '../../value/number';
+import {LegacyValueBase} from './base';
+
+export class LegacyNumber extends LegacyValueBase<SassNumber> {
+  constructor(valueOrInner: number | SassNumber, unit?: string) {
+    super(
+      valueOrInner instanceof SassNumber
+        ? valueOrInner
+        : parseNumber(valueOrInner, unit)
+    );
+  }
+
+  getValue(): number {
+    return this.inner.value;
+  }
+
+  setValue(value: number): void {
+    this.inner = new SassNumber(value, {
+      numeratorUnits: this.inner.numeratorUnits,
+      denominatorUnits: this.inner.denominatorUnits,
+    });
+  }
+
+  getUnit(): string {
+    return (
+      this.inner.numeratorUnits.join('*') +
+      (this.inner.denominatorUnits.size === 0 ? '' : '/') +
+      this.inner.denominatorUnits.join('*')
+    );
+  }
+
+  setUnit(unit: string): void {
+    this.inner = parseNumber(this.inner.value, unit);
+  }
+}
+
+Object.defineProperty(LegacyNumber, 'name', {value: 'sass.types.Number'});
+
+// Parses a `SassNumber` from `value` and `unit`, using Node Sass's unit
+// format.
+function parseNumber(value: number, unit?: string): SassNumber {
+  if (!unit) return new SassNumber(value);
+
+  if (!unit.includes('*') && !unit.includes('/')) {
+    return new SassNumber(value, unit);
+  }
+
+  const invalidUnit = new Error(`Unit ${unit} is invalid`);
+
+  const operands = unit.split('/');
+  if (operands.length > 2) throw invalidUnit;
+
+  const numerator = operands[0];
+  const denominator = operands.length === 1 ? null : operands[1];
+
+  const numeratorUnits = numerator.length === 0 ? [] : numerator.split('*');
+  if (numeratorUnits.some(unit => unit.length === 0)) throw invalidUnit;
+
+  const denominatorUnits = denominator === null ? [] : denominator.split('*');
+  if (denominatorUnits.some(unit => unit.length === 0)) throw invalidUnit;
+
+  return new SassNumber(value, {
+    numeratorUnits: numeratorUnits,
+    denominatorUnits: denominatorUnits,
+  });
+}

--- a/lib/src/legacy/value/string.ts
+++ b/lib/src/legacy/value/string.ts
@@ -1,0 +1,26 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {SassString} from '../../value/string';
+import {LegacyValueBase} from './base';
+
+export class LegacyString extends LegacyValueBase<SassString> {
+  constructor(valueOrInner: string | SassString) {
+    if (valueOrInner instanceof SassString) {
+      super(valueOrInner);
+    } else {
+      super(new SassString(valueOrInner, {quotes: false}));
+    }
+  }
+
+  getValue(): string {
+    return this.inner.text;
+  }
+
+  setValue(value: string): void {
+    this.inner = new SassString(value, {quotes: false});
+  }
+}
+
+Object.defineProperty(LegacyString, 'name', {value: 'sass.types.String'});

--- a/lib/src/legacy/value/wrap.ts
+++ b/lib/src/legacy/value/wrap.ts
@@ -1,0 +1,90 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as util from 'util';
+
+import {LegacyValueBase} from './base';
+import {LegacyColor} from './color';
+import {LegacyList} from './list';
+import {LegacyMap} from './map';
+import {LegacyNumber} from './number';
+import {LegacyString} from './string';
+import {PromiseOr, SyncBoolean} from '../../utils';
+import {Value} from '../../value';
+import {SassColor} from '../../value/color';
+import {SassList} from '../../value/list';
+import {SassMap} from '../../value/map';
+import {SassNumber} from '../../value/number';
+import {SassString} from '../../value/string';
+import {
+  CustomFunction,
+  LegacyFunction,
+  LegacyPluginThis,
+  LegacyValue,
+} from '../../vendor/sass';
+import * as types from '../../vendor/sass';
+
+/**
+ * Converts a `LegacyFunction` into a `CustomFunction` so it can be passed to
+ * the new JS API.
+ */
+export function wrapFunction<sync extends 'sync' | 'async'>(
+  thisArg: LegacyPluginThis,
+  callback: LegacyFunction<sync>,
+  sync: SyncBoolean<sync>
+): CustomFunction<sync> {
+  if (sync) {
+    return args =>
+      unwrapTypedValue(
+        (callback as LegacyFunction<'sync'>).apply(thisArg, args.map(wrapValue))
+      );
+  } else {
+    return args =>
+      new Promise((resolve, reject) => {
+        const done = (result: unknown) => {
+          try {
+            if (result instanceof Error) {
+              reject(result);
+            } else {
+              resolve(unwrapTypedValue(result));
+            }
+          } catch (error: unknown) {
+            reject(error);
+          }
+        };
+
+        // The cast here is necesary to work around microsoft/TypeScript#33815.
+        const syncResult = (callback as (...args: unknown[]) => unknown).apply(
+          thisArg,
+          [...args.map(wrapValue), done]
+        );
+
+        if (syncResult !== undefined) resolve(unwrapTypedValue(syncResult));
+      }) as PromiseOr<types.Value, sync>;
+  }
+}
+
+// Like `unwrapValue()`, but returns a `types.Value` type.
+function unwrapTypedValue(value: unknown): types.Value {
+  return unwrapValue(value) as types.Value;
+}
+
+/** Converts a value returned by a `LegacyFunction` into a `Value`. */
+export function unwrapValue(value: unknown): Value {
+  if (value instanceof Error) throw value;
+  if (value instanceof Value) return value;
+  if (value instanceof LegacyValueBase) return value.inner;
+  throw new Error(`Expected legacy Sass value, got ${util.inspect(value)}.`);
+}
+
+/** Converts a `Value` into a `LegacyValue`. */
+export function wrapValue(value: Value | types.Value): LegacyValue {
+  if (value instanceof SassColor) return new LegacyColor(value);
+  if (value instanceof SassList) return new LegacyList(value);
+  if (value instanceof SassMap) return new LegacyMap(value);
+  if (value instanceof SassNumber) return new LegacyNumber(value);
+  if (value instanceof SassString) return new LegacyString(value);
+  if (value instanceof Value) return value;
+  throw new Error(`Expected Sass value, got ${util.inspect(value)}.`);
+}

--- a/lib/src/message-transformer.test.ts
+++ b/lib/src/message-transformer.test.ts
@@ -1,0 +1,145 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {Subject, Observable} from 'rxjs';
+
+import {expectObservableToError} from '../../test/utils';
+import {MessageTransformer, OutboundTypedMessage} from './message-transformer';
+import {
+  InboundMessage,
+  OutboundMessage,
+  ProtocolError,
+} from './vendor/embedded-protocol/embedded_sass_pb';
+
+describe('message transformer', () => {
+  let messages: MessageTransformer;
+
+  function validInboundMessage(source: string): InboundMessage {
+    const input = new InboundMessage.CompileRequest.StringInput();
+    input.setSource(source);
+    const request = new InboundMessage.CompileRequest();
+    request.setString(input);
+    const message = new InboundMessage();
+    message.setCompileRequest(request);
+    return message;
+  }
+
+  describe('encode', () => {
+    let encodedProtobufs: Buffer[];
+
+    beforeEach(() => {
+      encodedProtobufs = [];
+      messages = new MessageTransformer(new Observable(), buffer =>
+        encodedProtobufs.push(buffer)
+      );
+    });
+
+    it('encodes an InboundMessage to buffer', () => {
+      const message = validInboundMessage('a {b: c}');
+
+      messages.writeInboundMessage({
+        payload: message.getCompileRequest()!,
+        type: InboundMessage.MessageCase.COMPILE_REQUEST,
+      });
+
+      expect(encodedProtobufs).toEqual([
+        Buffer.from(message.serializeBinary()),
+      ]);
+    });
+  });
+
+  describe('decode', () => {
+    let protobufs$: Subject<Buffer>;
+    let decodedMessages: OutboundTypedMessage[];
+
+    beforeEach(() => {
+      protobufs$ = new Subject();
+      messages = new MessageTransformer(protobufs$, () => {});
+      decodedMessages = [];
+    });
+
+    it('decodes buffer to OutboundMessage', done => {
+      const message = validInboundMessage('a {b: c}');
+
+      messages.outboundMessages$.subscribe({
+        next: message => decodedMessages.push(message),
+        complete: () => {
+          expect(decodedMessages.length).toBe(1);
+          const response = decodedMessages[0]
+            .payload as OutboundMessage.CompileResponse;
+          expect(response.getSuccess()?.getCss()).toBe('a {b: c}');
+          const type = decodedMessages[0].type;
+          expect(type).toEqual(OutboundMessage.MessageCase.COMPILE_RESPONSE);
+          done();
+        },
+      });
+
+      protobufs$.next(Buffer.from(message.serializeBinary()));
+      protobufs$.complete();
+    });
+
+    describe('protocol error', () => {
+      it('fails on invalid buffer', done => {
+        expectObservableToError(
+          messages.outboundMessages$,
+          'Compiler caused error: Invalid buffer.',
+          done
+        );
+
+        protobufs$.next(Buffer.from([-1]));
+      });
+
+      it('fails on empty message', done => {
+        expectObservableToError(
+          messages.outboundMessages$,
+          'Compiler caused error: OutboundMessage.message is not set.',
+          done
+        );
+
+        protobufs$.next(Buffer.from(new OutboundMessage().serializeBinary()));
+      });
+
+      it('fails on compile response with missing result', done => {
+        expectObservableToError(
+          messages.outboundMessages$,
+          'Compiler caused error: OutboundMessage.CompileResponse.result is not set.',
+          done
+        );
+
+        const response = new OutboundMessage.CompileResponse();
+        const message = new OutboundMessage();
+        message.setCompileResponse(response);
+        protobufs$.next(Buffer.from(message.serializeBinary()));
+      });
+
+      it('fails on function call request with missing identifier', done => {
+        expectObservableToError(
+          messages.outboundMessages$,
+          'Compiler caused error: OutboundMessage.FunctionCallRequest.identifier is not set.',
+          done
+        );
+
+        const request = new OutboundMessage.FunctionCallRequest();
+        const message = new OutboundMessage();
+        message.setFunctionCallRequest(request);
+        protobufs$.next(Buffer.from(message.serializeBinary()));
+      });
+
+      it('fails if message contains a protocol error', done => {
+        const errorMessage = 'sad';
+        expectObservableToError(
+          messages.outboundMessages$,
+          `Compiler reported error: ${errorMessage}.`,
+          done
+        );
+
+        const error = new ProtocolError();
+        error.setMessage(errorMessage);
+        const message = new OutboundMessage();
+        message.setError(error);
+        protobufs$.next(Buffer.from(message.serializeBinary()));
+      });
+    });
+  });
+});

--- a/lib/src/message-transformer.ts
+++ b/lib/src/message-transformer.ts
@@ -1,0 +1,198 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {Observable, Subject} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+import {compilerError, hostError} from './utils';
+import {
+  InboundMessage,
+  OutboundMessage,
+} from './vendor/embedded-protocol/embedded_sass_pb';
+
+export type InboundRequestType = InboundMessage.MessageCase.COMPILE_REQUEST;
+
+export type InboundRequest = InboundMessage.CompileRequest;
+
+export type InboundResponseType =
+  | InboundMessage.MessageCase.IMPORT_RESPONSE
+  | InboundMessage.MessageCase.FILE_IMPORT_RESPONSE
+  | InboundMessage.MessageCase.CANONICALIZE_RESPONSE
+  | InboundMessage.MessageCase.FUNCTION_CALL_RESPONSE;
+
+export type InboundResponse =
+  | InboundMessage.ImportResponse
+  | InboundMessage.FileImportResponse
+  | InboundMessage.CanonicalizeResponse
+  | InboundMessage.FunctionCallResponse;
+
+export type OutboundRequestType =
+  | OutboundMessage.MessageCase.IMPORT_REQUEST
+  | OutboundMessage.MessageCase.FILE_IMPORT_REQUEST
+  | OutboundMessage.MessageCase.CANONICALIZE_REQUEST
+  | OutboundMessage.MessageCase.FUNCTION_CALL_REQUEST;
+
+export type OutboundRequest =
+  | OutboundMessage.ImportRequest
+  | OutboundMessage.FileImportRequest
+  | OutboundMessage.CanonicalizeRequest
+  | OutboundMessage.FunctionCallRequest;
+
+export type OutboundResponseType = OutboundMessage.MessageCase.COMPILE_RESPONSE;
+
+export type OutboundResponse = OutboundMessage.CompileResponse;
+
+export type OutboundEventType = OutboundMessage.MessageCase.LOG_EVENT;
+
+export type OutboundEvent = OutboundMessage.LogEvent;
+
+export type InboundTypedMessage = {
+  payload: InboundRequest | InboundResponse;
+  type: InboundRequestType | InboundResponseType;
+};
+
+export type OutboundTypedMessage = {
+  payload: OutboundRequest | OutboundResponse | OutboundEvent;
+  type: OutboundRequestType | OutboundResponseType | OutboundEventType;
+};
+
+/**
+ * Encodes InboundTypedMessages into protocol buffers and decodes protocol
+ * buffers into OutboundTypedMessages. Any Embedded Protocol violations that can
+ * be detected at the message level are encapsulated here and reported as
+ * errors.
+ *
+ * This transformer communicates via In/OutboundTypedMessages instead of raw
+ * In/OutboundMessages in order to expose more type information to consumers.
+ * This makes the stream of messages from the transformer easier to interact
+ * with.
+ */
+export class MessageTransformer {
+  // The decoded messages are written to this Subject. It is publicly exposed
+  // as a readonly Observable.
+  private readonly outboundMessagesInternal$ =
+    new Subject<OutboundTypedMessage>();
+
+  /**
+   * The OutboundTypedMessages, decoded from protocol buffers. If any errors are
+   * detected while encoding/decoding, this Observable will error out.
+   */
+  readonly outboundMessages$ = this.outboundMessagesInternal$.pipe();
+
+  constructor(
+    private readonly outboundProtobufs$: Observable<Buffer>,
+    private readonly writeInboundProtobuf: (buffer: Buffer) => void
+  ) {
+    this.outboundProtobufs$
+      .pipe(map(decode))
+      .subscribe(this.outboundMessagesInternal$);
+  }
+
+  /**
+   * Converts the inbound `message` to a protocol buffer.
+   */
+  writeInboundMessage(message: InboundTypedMessage): void {
+    try {
+      this.writeInboundProtobuf(encode(message));
+    } catch (error) {
+      this.outboundMessagesInternal$.error(error);
+    }
+  }
+}
+
+// Decodes a protobuf `buffer` into an OutboundTypedMessage, ensuring that all
+// mandatory message fields are populated. Throws if `buffer` cannot be decoded
+// into a valid message, or if the message itself contains a Protocol Error.
+function decode(buffer: Buffer): OutboundTypedMessage {
+  let message;
+  try {
+    message = OutboundMessage.deserializeBinary(buffer);
+  } catch (error) {
+    throw compilerError('Invalid buffer');
+  }
+
+  let payload;
+  const type = message.getMessageCase();
+  switch (type) {
+    case OutboundMessage.MessageCase.LOG_EVENT:
+      payload = message.getLogEvent();
+      break;
+    case OutboundMessage.MessageCase.COMPILE_RESPONSE:
+      if (
+        message.getCompileResponse()?.getResultCase() ===
+        OutboundMessage.CompileResponse.ResultCase.RESULT_NOT_SET
+      ) {
+        throw compilerError(
+          'OutboundMessage.CompileResponse.result is not set'
+        );
+      }
+      payload = message.getCompileResponse();
+      break;
+    case OutboundMessage.MessageCase.IMPORT_REQUEST:
+      payload = message.getImportRequest();
+      break;
+    case OutboundMessage.MessageCase.FILE_IMPORT_REQUEST:
+      payload = message.getFileImportRequest();
+      break;
+    case OutboundMessage.MessageCase.CANONICALIZE_REQUEST:
+      payload = message.getCanonicalizeRequest();
+      break;
+    case OutboundMessage.MessageCase.FUNCTION_CALL_REQUEST:
+      if (
+        message.getFunctionCallRequest()?.getIdentifierCase() ===
+        OutboundMessage.FunctionCallRequest.IdentifierCase.IDENTIFIER_NOT_SET
+      ) {
+        throw compilerError(
+          'OutboundMessage.FunctionCallRequest.identifier is not set'
+        );
+      }
+      payload = message.getFunctionCallRequest();
+      break;
+    case OutboundMessage.MessageCase.ERROR:
+      throw hostError(`${message.getError()?.getMessage()}`);
+    case OutboundMessage.MessageCase.MESSAGE_NOT_SET:
+      throw compilerError('OutboundMessage.message is not set');
+    default:
+      throw compilerError(`Unknown message type ${message.toString()}`);
+  }
+
+  if (!payload) throw compilerError('OutboundMessage missing payload');
+  return {
+    payload,
+    type,
+  };
+}
+
+// Encodes an InboundTypedMessage into a protocol buffer.
+function encode(message: InboundTypedMessage): Buffer {
+  const inboundMessage = new InboundMessage();
+  switch (message.type) {
+    case InboundMessage.MessageCase.COMPILE_REQUEST:
+      inboundMessage.setCompileRequest(
+        message.payload as InboundMessage.CompileRequest
+      );
+      break;
+    case InboundMessage.MessageCase.IMPORT_RESPONSE:
+      inboundMessage.setImportResponse(
+        message.payload as InboundMessage.ImportResponse
+      );
+      break;
+    case InboundMessage.MessageCase.FILE_IMPORT_RESPONSE:
+      inboundMessage.setFileImportResponse(
+        message.payload as InboundMessage.FileImportResponse
+      );
+      break;
+    case InboundMessage.MessageCase.CANONICALIZE_RESPONSE:
+      inboundMessage.setCanonicalizeResponse(
+        message.payload as InboundMessage.CanonicalizeResponse
+      );
+      break;
+    case InboundMessage.MessageCase.FUNCTION_CALL_RESPONSE:
+      inboundMessage.setFunctionCallResponse(
+        message.payload as InboundMessage.FunctionCallResponse
+      );
+      break;
+  }
+  return Buffer.from(inboundMessage.serializeBinary());
+}

--- a/lib/src/packet-transformer.test.ts
+++ b/lib/src/packet-transformer.test.ts
@@ -1,0 +1,162 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {Subject, Observable} from 'rxjs';
+
+import {PacketTransformer} from './packet-transformer';
+
+describe('packet transformer', () => {
+  let packets: PacketTransformer;
+
+  describe('encode', () => {
+    let encodedBuffers: Buffer[];
+
+    beforeEach(() => {
+      encodedBuffers = [];
+      packets = new PacketTransformer(new Observable(), buffer =>
+        encodedBuffers.push(buffer)
+      );
+    });
+
+    it('encodes an empty message', () => {
+      packets.writeInboundProtobuf(Buffer.from([]));
+
+      expect(encodedBuffers).toEqual([Buffer.from([0])]);
+    });
+
+    it('encodes a message of length 1', () => {
+      packets.writeInboundProtobuf(Buffer.from([123]));
+
+      expect(encodedBuffers).toEqual([Buffer.from([1, 123])]);
+    });
+
+    it('encodes a message of length greater than 256', () => {
+      packets.writeInboundProtobuf(Buffer.alloc(300, 1));
+
+      expect(encodedBuffers).toEqual([
+        Buffer.from([172, 2, ...new Array(300).fill(1)]),
+      ]);
+    });
+
+    it('encodes multiple messages', () => {
+      packets.writeInboundProtobuf(Buffer.from([10]));
+      packets.writeInboundProtobuf(Buffer.from([20, 30]));
+      packets.writeInboundProtobuf(Buffer.from([40, 50, 60]));
+
+      expect(encodedBuffers).toEqual([
+        Buffer.from([1, 10]),
+        Buffer.from([2, 20, 30]),
+        Buffer.from([3, 40, 50, 60]),
+      ]);
+    });
+  });
+
+  describe('decode', () => {
+    let rawBuffers$: Subject<Buffer>;
+
+    function expectDecoding(expected: Buffer[], done: () => void) {
+      const actual: Buffer[] = [];
+      packets.outboundProtobufs$.subscribe({
+        next: protobuf => actual.push(protobuf),
+        error: () => fail('expected correct decoding'),
+        complete: () => {
+          expect(actual).toEqual(expected);
+          done();
+        },
+      });
+    }
+
+    beforeEach(() => {
+      rawBuffers$ = new Subject();
+      packets = new PacketTransformer(rawBuffers$, () => {});
+    });
+
+    describe('empty message', () => {
+      it('decodes a single chunk', done => {
+        expectDecoding([Buffer.from([])], done);
+
+        rawBuffers$.next(Buffer.from([0]));
+        rawBuffers$.complete();
+      });
+
+      it('decodes a chunk that contains more data', done => {
+        expectDecoding([Buffer.from([]), Buffer.from([100])], done);
+
+        rawBuffers$.next(Buffer.from([0, 1, 100]));
+        rawBuffers$.complete();
+      });
+    });
+
+    describe('longer message', () => {
+      it('decodes a single chunk', done => {
+        expectDecoding([Buffer.from(Buffer.from([1, 2, 3, 4]))], done);
+
+        rawBuffers$.next(Buffer.from([4, 1, 2, 3, 4]));
+        rawBuffers$.complete();
+      });
+
+      it('decodes multiple chunks', done => {
+        expectDecoding([Buffer.alloc(300, 1)], done);
+
+        rawBuffers$.next(Buffer.from([172]));
+        rawBuffers$.next(Buffer.from([2, 1]));
+        rawBuffers$.next(Buffer.from(Buffer.alloc(299, 1)));
+        rawBuffers$.complete();
+      });
+
+      it('decodes one chunk per byte', done => {
+        expectDecoding([Buffer.alloc(300, 1)], done);
+
+        for (const byte of [172, 2, ...Buffer.alloc(300, 1)]) {
+          rawBuffers$.next(Buffer.from([byte]));
+        }
+        rawBuffers$.complete();
+      });
+
+      it('decodes a chunk that contains more data', done => {
+        expectDecoding([Buffer.from([1, 2, 3, 4]), Buffer.from([0])], done);
+
+        rawBuffers$.next(Buffer.from([4, 1, 2, 3, 4, 1, 0]));
+        rawBuffers$.complete();
+      });
+
+      it('decodes a full chunk of length greater than 256', done => {
+        expectDecoding([Buffer.from(new Array(300).fill(1))], done);
+
+        rawBuffers$.next(Buffer.from([172, 2, ...new Array(300).fill(1)]));
+        rawBuffers$.complete();
+      });
+    });
+
+    describe('multiple messages', () => {
+      it('decodes a single chunk', done => {
+        expectDecoding(
+          [Buffer.from([1, 2, 3, 4]), Buffer.from([101, 102])],
+          done
+        );
+
+        rawBuffers$.next(Buffer.from([4, 1, 2, 3, 4, 2, 101, 102]));
+        rawBuffers$.complete();
+      });
+
+      it('decodes multiple chunks', done => {
+        expectDecoding([Buffer.from([1, 2, 3, 4]), Buffer.alloc(300, 1)], done);
+
+        rawBuffers$.next(Buffer.from([4]));
+        rawBuffers$.next(Buffer.from([1, 2, 3, 4, 172]));
+        rawBuffers$.next(Buffer.from([2, ...Buffer.alloc(300, 1)]));
+        rawBuffers$.complete();
+      });
+
+      it('decodes one chunk per byte', done => {
+        expectDecoding([Buffer.from([1, 2, 3, 4]), Buffer.alloc(300, 1)], done);
+
+        for (const byte of [4, 1, 2, 3, 4, 172, 2, ...Buffer.alloc(300, 1)]) {
+          rawBuffers$.next(Buffer.from([byte]));
+        }
+        rawBuffers$.complete();
+      });
+    });
+  });
+});

--- a/lib/src/packet-transformer.ts
+++ b/lib/src/packet-transformer.ts
@@ -1,0 +1,185 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {Observable, Subject} from 'rxjs';
+import {mergeMap} from 'rxjs/operators';
+import BufferBuilder = require('buffer-builder');
+
+/**
+ * Decodes arbitrarily-chunked buffers, for example
+ *   [ 0 1 2 3 4 5 6 7 ... ],
+ * into packets of set length in the form
+ *   +---------+------------- ...
+ *   | 0 1 2 3 | 4 5 6 7 ...
+ *   +---------+------------- ...
+ *   | HEADER  | PAYLOAD (PROTOBUF)
+ *   +---------+------------- ...
+ * and emits the payload of each packet.
+ *
+ * Encodes packets by attaching a header to a protobuf that describes the
+ * protobuf's length.
+ */
+export class PacketTransformer {
+  // The packet that is actively being decoded as buffers come in.
+  private packet = new Packet();
+
+  // The decoded protobufs are written to this Subject. It is publicly exposed
+  // as a readonly Observable.
+  private readonly outboundProtobufsInternal$ = new Subject<Buffer>();
+
+  /**
+   * The fully-decoded, outbound protobufs. If any errors are encountered
+   * during encoding/decoding, this Observable will error out.
+   */
+  readonly outboundProtobufs$ = this.outboundProtobufsInternal$.pipe();
+
+  constructor(
+    private readonly outboundBuffers$: Observable<Buffer>,
+    private readonly writeInboundBuffer: (buffer: Buffer) => void
+  ) {
+    this.outboundBuffers$
+      .pipe(mergeMap(buffer => this.decode(buffer)))
+      .subscribe(this.outboundProtobufsInternal$);
+  }
+
+  /**
+   * Encodes a packet by pre-fixing `protobuf` with a header that describes its
+   * length.
+   */
+  writeInboundProtobuf(protobuf: Buffer): void {
+    try {
+      let length = protobuf.length;
+      if (length === 0) {
+        this.writeInboundBuffer(Buffer.alloc(1));
+        return;
+      }
+
+      // Write the length in varint format, 7 bits at a time from least to most
+      // significant.
+      const header = new BufferBuilder(8);
+      while (length > 0) {
+        // The highest-order bit indicates whether more bytes are necessary to
+        // fully express the number. The lower 7 bits indicate the number's
+        // value.
+        header.appendUInt8((length > 0x7f ? 0x80 : 0) | (length & 0x7f));
+        length >>= 7;
+      }
+
+      const packet = Buffer.alloc(header.length + protobuf.length);
+      header.copy(packet);
+      packet.set(protobuf, header.length);
+      this.writeInboundBuffer(packet);
+    } catch (error) {
+      this.outboundProtobufsInternal$.error(error);
+    }
+  }
+
+  // Decodes a buffer, filling up the packet that is actively being decoded.
+  // Returns a list of decoded payloads.
+  private decode(buffer: Buffer): Buffer[] {
+    const payloads: Buffer[] = [];
+    let decodedBytes = 0;
+    while (decodedBytes < buffer.length) {
+      decodedBytes += this.packet.write(buffer.slice(decodedBytes));
+      if (this.packet.isComplete && this.packet.payload) {
+        payloads.push(this.packet.payload);
+        this.packet = new Packet();
+      }
+    }
+    return payloads;
+  }
+}
+
+/** A length-delimited packet comprised of a header and payload. */
+class Packet {
+  // The number of bits we've consumed so far to fill out `payloadLength`.
+  private payloadLengthBits = 0;
+
+  // The length of the next message, in bytes.
+  //
+  // This is built up from a [varint]. Once it's fully consumed, `payload` is
+  // initialized and this is reset to 0.
+  //
+  // [varint]: https://developers.google.com/protocol-buffers/docs/encoding#varints
+  private payloadLength = 0;
+
+  /**
+   * The packet's payload. Constructed by calls to write().
+   * @see write
+   */
+  payload?: Buffer;
+
+  // The offset in [payload] that should be written to next time data arrives.
+  private payloadOffset = 0;
+
+  /** Whether the packet construction is complete. */
+  get isComplete(): boolean {
+    return !!(this.payload && this.payloadOffset >= this.payloadLength);
+  }
+
+  /**
+   * Takes arbitrary binary input and slots it into the header and payload
+   * appropriately. Returns the number of bytes that were written into the
+   * packet. This method can be called repeatedly, incrementally building
+   * up the packet until it is complete.
+   */
+  write(source: Buffer): number {
+    if (this.isComplete) {
+      throw Error('Cannot write to a completed Packet.');
+    }
+
+    // The index of the next byte to read from [source]. We have to track this
+    // because the source may contain the length *and* the message.
+    let i = 0;
+
+    // We can be in one of two states here:
+    //
+    // * [payload] is `null`, in which case we're adding data to [payloadLength]
+    //   until we reach a byte with its most significant bit set to 0.
+    //
+    // * [payload] is not `null`, in which case we're waiting for
+    //   [payloadOffset] to reach [payloadLength] bytes in it so this packet is
+    //   complete.
+    if (!this.payload) {
+      for (;;) {
+        const byte = source[i];
+
+        // Varints encode data in the 7 lower bits of each byte, which we access
+        // by masking with 0x7f = 0b01111111.
+        this.payloadLength += (byte & 0x7f) << this.payloadLengthBits;
+        this.payloadLengthBits += 7;
+        i++;
+
+        if (byte <= 0x7f) {
+          // If the byte is lower than 0x7f = 0b01111111, that means its high
+          // bit is unset which and we now know the full message length and can
+          // initialize [this.payload].
+          this.payload = Buffer.alloc(this.payloadLength);
+          break;
+        } else if (i === source.length) {
+          // If we've hit the end of the source chunk, we need to wait for the
+          // next chunk to arrive. Just return the number of bytes we've
+          // consumed so far.
+          return i;
+        } else {
+          // Otherwise, we continue reading bytes from the source data to fill
+          // in [this.payloadLength].
+        }
+      }
+    }
+
+    // Copy as many bytes as we can from [source] to [payload], making sure not
+    // to try to copy more than the payload can hold (if the source has another
+    // message after the current one) or more than the source has available (if
+    // the current message is split across multiple chunks).
+    const bytesToWrite = Math.min(
+      this.payload.length - this.payloadOffset,
+      source.length - i
+    );
+    this.payload.set(source.subarray(i, i + bytesToWrite), this.payloadOffset);
+    this.payloadOffset += bytesToWrite;
+
+    return i + bytesToWrite;
+  }
+}

--- a/lib/src/protofier.ts
+++ b/lib/src/protofier.ts
@@ -1,0 +1,306 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {OrderedMap} from 'immutable';
+
+import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as utils from './utils';
+import {FunctionRegistry} from './function-registry';
+import {SassArgumentList} from './value/argument-list';
+import {SassColor} from './value/color';
+import {SassFunction} from './value/function';
+import {SassList, ListSeparator} from './value/list';
+import {SassMap} from './value/map';
+import {SassNumber} from './value/number';
+import {SassString} from './value/string';
+import {Value} from './value';
+import {sassNull} from './value/null';
+import {sassTrue, sassFalse} from './value/boolean';
+
+/**
+ * A class that converts [Value] objects into protobufs.
+ *
+ * A given [Protofier] instance is valid only within the scope of a single
+ * custom function call.
+ */
+export class Protofier {
+  /** All the argument lists returned by `deprotofy()`. */
+  private readonly argumentLists: SassArgumentList[] = [];
+
+  /**
+   * Returns IDs of all argument lists passed to `deprotofy()` whose keywords
+   * have been accessed.
+   */
+  get accessedArgumentLists(): number[] {
+    return this.argumentLists
+      .filter(list => list.keywordsAccessed)
+      .map(list => list.id);
+  }
+
+  constructor(
+    /**
+     * The registry of custom functions that can be invoked by the compiler.
+     * This is used to register first-class functions so that the compiler may
+     * invoke them.
+     */
+    private readonly functions: FunctionRegistry<'sync' | 'async'>
+  ) {}
+
+  /** Converts `value` to its protocol buffer representation. */
+  protofy(value: Value): proto.Value {
+    const result = new proto.Value();
+    if (value instanceof SassString) {
+      const string = new proto.Value.String();
+      string.setText(value.text);
+      string.setQuoted(value.hasQuotes);
+      result.setString(string);
+    } else if (value instanceof SassNumber) {
+      result.setNumber(this.protofyNumber(value));
+    } else if (value instanceof SassColor) {
+      if (value.hasCalculatedHsl) {
+        const color = new proto.Value.HslColor();
+        color.setHue(value.hue);
+        color.setSaturation(value.saturation);
+        color.setLightness(value.lightness);
+        color.setAlpha(value.alpha);
+        result.setHslColor(color);
+      } else {
+        const color = new proto.Value.RgbColor();
+        color.setRed(value.red);
+        color.setGreen(value.green);
+        color.setBlue(value.blue);
+        color.setAlpha(value.alpha);
+        result.setRgbColor(color);
+      }
+    } else if (value instanceof SassList) {
+      const list = new proto.Value.List();
+      list.setSeparator(this.protofySeparator(value.separator));
+      list.setHasBrackets(value.hasBrackets);
+      for (const element of value.asList) {
+        list.addContents(this.protofy(element));
+      }
+      result.setList(list);
+    } else if (value instanceof SassArgumentList) {
+      const list = new proto.Value.ArgumentList();
+      list.setId(value.id);
+      list.setSeparator(this.protofySeparator(value.separator));
+      for (const element of value.asList) {
+        list.addContents(this.protofy(element));
+      }
+      const keywords = list.getKeywordsMap();
+      for (const [key, mapValue] of value.keywordsInternal) {
+        keywords.set(key, this.protofy(mapValue));
+      }
+      result.setArgumentList(list);
+    } else if (value instanceof SassMap) {
+      const map = new proto.Value.Map();
+      for (const [key, mapValue] of value.contents) {
+        const entry = new proto.Value.Map.Entry();
+        entry.setKey(this.protofy(key));
+        entry.setValue(this.protofy(mapValue));
+        map.addEntries(entry);
+      }
+      result.setMap(map);
+    } else if (value instanceof SassFunction) {
+      if (value.id !== undefined) {
+        const fn = new proto.Value.CompilerFunction();
+        fn.setId(value.id);
+        result.setCompilerFunction(fn);
+      } else {
+        const fn = new proto.Value.HostFunction();
+        fn.setId(this.functions.register(value.callback!));
+        fn.setSignature(value.signature!);
+        result.setHostFunction(fn);
+      }
+    } else if (value === sassTrue) {
+      result.setSingleton(proto.SingletonValue.TRUE);
+    } else if (value === sassFalse) {
+      result.setSingleton(proto.SingletonValue.FALSE);
+    } else if (value === sassNull) {
+      result.setSingleton(proto.SingletonValue.NULL);
+    } else {
+      throw utils.compilerError(`Unknown Value ${value}`);
+    }
+    return result;
+  }
+
+  /** Converts `number` to its protocol buffer representation. */
+  private protofyNumber(number: SassNumber): proto.Value.Number {
+    const value = new proto.Value.Number();
+    value.setValue(number.value);
+    for (const unit of number.numeratorUnits) {
+      value.addNumerators(unit);
+    }
+    for (const unit of number.denominatorUnits) {
+      value.addDenominators(unit);
+    }
+    return value;
+  }
+
+  /** Converts `separator` to its protocol buffer representation. */
+  private protofySeparator(
+    separator: ListSeparator
+  ): proto.ListSeparatorMap[keyof proto.ListSeparatorMap] {
+    switch (separator) {
+      case ',':
+        return proto.ListSeparator.COMMA;
+      case ' ':
+        return proto.ListSeparator.SPACE;
+      case '/':
+        return proto.ListSeparator.SLASH;
+      case null:
+        return proto.ListSeparator.UNDECIDED;
+      default:
+        throw utils.compilerError(`Unknown ListSeparator ${separator}`);
+    }
+  }
+
+  /** Converts `value` to its JS representation. */
+  deprotofy(value: proto.Value): Value {
+    switch (value.getValueCase()) {
+      case proto.Value.ValueCase.STRING: {
+        const string = value.getString()!;
+        return string.getText().length === 0
+          ? SassString.empty({quotes: string.getQuoted()})
+          : new SassString(string.getText(), {quotes: string.getQuoted()});
+      }
+
+      case proto.Value.ValueCase.NUMBER:
+        return this.deprotofyNumber(value.getNumber()!);
+
+      case proto.Value.ValueCase.RGB_COLOR: {
+        const color = value.getRgbColor()!;
+        return new SassColor({
+          red: color.getRed(),
+          green: color.getGreen(),
+          blue: color.getBlue(),
+          alpha: color.getAlpha(),
+        });
+      }
+
+      case proto.Value.ValueCase.HSL_COLOR: {
+        const color = value.getHslColor()!;
+        return new SassColor({
+          hue: color.getHue(),
+          saturation: color.getSaturation(),
+          lightness: color.getLightness(),
+          alpha: color.getAlpha(),
+        });
+      }
+
+      case proto.Value.ValueCase.LIST: {
+        const list = value.getList()!;
+        const separator = this.deprotofySeparator(list.getSeparator());
+
+        const contents = list.getContentsList();
+        if (separator === null && contents.length > 1) {
+          throw utils.compilerError(
+            `Value.List ${list} can't have an undecided separator because it ` +
+              `has ${contents.length} elements`
+          );
+        }
+
+        return new SassList(
+          contents.map(element => this.deprotofy(element)),
+          {separator, brackets: list.getHasBrackets()}
+        );
+      }
+
+      case proto.Value.ValueCase.ARGUMENT_LIST: {
+        const list = value.getArgumentList()!;
+        const separator = this.deprotofySeparator(list.getSeparator());
+
+        const contents = list.getContentsList();
+        if (separator === null && contents.length > 1) {
+          throw utils.compilerError(
+            `Value.List ${list} can't have an undecided separator because it ` +
+              `has ${contents.length} elements`
+          );
+        }
+
+        const result = new SassArgumentList(
+          contents.map(element => this.deprotofy(element)),
+          OrderedMap(
+            [...list.getKeywordsMap().entries()].map(([key, value]) => [
+              key,
+              this.deprotofy(value),
+            ])
+          ),
+          separator,
+          list.getId()
+        );
+        this.argumentLists.push(result);
+        return result;
+      }
+
+      case proto.Value.ValueCase.MAP:
+        return new SassMap(
+          OrderedMap(
+            value
+              .getMap()!
+              .getEntriesList()
+              .map(entry => {
+                const key = entry.getKey();
+                if (!key) throw utils.mandatoryError('Value.Map.Entry.key');
+                const value = entry.getValue();
+                if (!value) throw utils.mandatoryError('Value.Map.Entry.value');
+
+                return [this.deprotofy(key), this.deprotofy(value)];
+              })
+          )
+        );
+
+      case proto.Value.ValueCase.COMPILER_FUNCTION:
+        return new SassFunction(value.getCompilerFunction()!.getId());
+
+      case proto.Value.ValueCase.HOST_FUNCTION:
+        throw utils.compilerError(
+          'The compiler may not send Value.host_function.'
+        );
+
+      case proto.Value.ValueCase.SINGLETON:
+        switch (value.getSingleton()) {
+          case proto.SingletonValue.TRUE:
+            return sassTrue;
+          case proto.SingletonValue.FALSE:
+            return sassFalse;
+          case proto.SingletonValue.NULL:
+            return sassNull;
+          default:
+            throw utils.compilerError(
+              `Unknown Value.singleton ${value.getSingleton()}`
+            );
+        }
+
+      default:
+        throw utils.mandatoryError('Value.value');
+    }
+  }
+
+  /** Converts `number` to its JS representation. */
+  private deprotofyNumber(number: proto.Value.Number): SassNumber {
+    return new SassNumber(number.getValue(), {
+      numeratorUnits: number.getNumeratorsList(),
+      denominatorUnits: number.getDenominatorsList(),
+    });
+  }
+
+  /** Converts `separator` to its JS representation. */
+  private deprotofySeparator(
+    separator: proto.ListSeparatorMap[keyof proto.ListSeparatorMap]
+  ): ListSeparator {
+    switch (separator) {
+      case proto.ListSeparator.COMMA:
+        return ',';
+      case proto.ListSeparator.SPACE:
+        return ' ';
+      case proto.ListSeparator.SLASH:
+        return '/';
+      case proto.ListSeparator.UNDECIDED:
+        return null;
+      default:
+        throw utils.compilerError(`Unknown separator ${separator}`);
+    }
+  }
+}

--- a/lib/src/request-tracker.test.ts
+++ b/lib/src/request-tracker.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {
+  InboundMessage,
+  OutboundMessage,
+} from './vendor/embedded-protocol/embedded_sass_pb';
+import {RequestTracker} from './request-tracker';
+
+describe('request tracker', () => {
+  let tracker: RequestTracker;
+
+  beforeEach(() => {
+    tracker = new RequestTracker();
+  });
+
+  it('returns the next ID when empty', () => {
+    expect(tracker.nextId).toBe(0);
+  });
+
+  describe('tracking requests', () => {
+    it('tracks when empty', () => {
+      tracker.add(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      expect(tracker.nextId).toBe(1);
+    });
+
+    it('tracks multiple requests', () => {
+      tracker.add(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.add(1, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.add(2, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      expect(tracker.nextId).toBe(3);
+    });
+
+    it('tracks starting from a non-zero ID', () => {
+      tracker.add(1, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      expect(tracker.nextId).toBe(0);
+      tracker.add(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      expect(tracker.nextId).toBe(2);
+    });
+
+    it('errors if the request ID is invalid', () => {
+      expect(() =>
+        tracker.add(-1, OutboundMessage.MessageCase.COMPILE_RESPONSE)
+      ).toThrowError('Invalid request ID -1.');
+    });
+
+    it('errors if the request ID overlaps that of an existing in-flight request', () => {
+      tracker.add(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      expect(() =>
+        tracker.add(0, OutboundMessage.MessageCase.COMPILE_RESPONSE)
+      ).toThrowError('Request ID 0 is already in use by an in-flight request.');
+    });
+  });
+
+  describe('resolving requests', () => {
+    it('resolves a single request', () => {
+      tracker.add(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.resolve(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      expect(tracker.nextId).toBe(0);
+    });
+
+    it('resolves multiple requests', () => {
+      tracker.add(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.add(1, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.add(2, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.resolve(1, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.resolve(2, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.resolve(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      expect(tracker.nextId).toBe(0);
+    });
+
+    it('reuses the ID of a resolved request', () => {
+      tracker.add(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.add(1, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      tracker.resolve(0, OutboundMessage.MessageCase.COMPILE_RESPONSE);
+      expect(tracker.nextId).toBe(0);
+    });
+
+    it('errors if the response ID does not match any existing request IDs', () => {
+      expect(() =>
+        tracker.resolve(0, OutboundMessage.MessageCase.COMPILE_RESPONSE)
+      ).toThrowError('Response ID 0 does not match any pending requests.');
+    });
+
+    it('errors if the response type does not match what the request is expecting', () => {
+      tracker.add(0, InboundMessage.MessageCase.IMPORT_RESPONSE);
+      expect(() =>
+        tracker.resolve(0, InboundMessage.MessageCase.FILE_IMPORT_RESPONSE)
+      ).toThrowError(
+        "Response with ID 0 does not match pending request's type. Expected 4 but received 5."
+      );
+    });
+  });
+});

--- a/lib/src/request-tracker.ts
+++ b/lib/src/request-tracker.ts
@@ -1,0 +1,60 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {InboundResponseType, OutboundResponseType} from './message-transformer';
+
+/**
+ * Manages pending inbound and outbound requests. Ensures that requests and
+ * responses interact correctly and obey the Embedded Protocol.
+ */
+export class RequestTracker {
+  // The indices of this array correspond to each pending request's ID. Stores
+  // the response type expected by each request.
+  private readonly requests: Array<
+    InboundResponseType | OutboundResponseType | null
+  > = [];
+
+  /** The next available request ID. */
+  get nextId() {
+    for (let i = 0; i < this.requests.length; i++) {
+      if (this.requests[i] === undefined || this.requests[i] === null) {
+        return i;
+      }
+    }
+    return this.requests.length;
+  }
+
+  /**
+   * Adds an entry for a pending request with ID `id`. The entry stores the
+   * expected response type. Throws an error if the Protocol Error is violated.
+   */
+  add(
+    id: number,
+    expectedResponseType: InboundResponseType | OutboundResponseType
+  ) {
+    if (id < 0) {
+      throw Error(`Invalid request ID ${id}.`);
+    } else if (this.requests[id]) {
+      throw Error(
+        `Request ID ${id} is already in use by an in-flight request.`
+      );
+    }
+    this.requests[id] = expectedResponseType;
+  }
+
+  /**
+   * Resolves a pending request with matching ID `id` and expected response type
+   * `type`. Throws an error if the Protocol Error is violated.
+   */
+  resolve(id: number, type: InboundResponseType | OutboundResponseType) {
+    if (this.requests[id] === undefined || this.requests[id] === null) {
+      throw Error(`Response ID ${id} does not match any pending requests.`);
+    } else if (this.requests[id] !== type) {
+      throw Error(
+        `Response with ID ${id} does not match pending request's type. Expected ${this.requests[id]} but received ${type}.`
+      );
+    }
+    this.requests[id] = null;
+  }
+}

--- a/lib/src/sync-compiler.ts
+++ b/lib/src/sync-compiler.ts
@@ -1,0 +1,60 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {Subject} from 'rxjs';
+
+import {SyncProcess} from './sync-process';
+import {compilerPath} from './compiler-path';
+
+/**
+ * A synchronous wrapper for the embedded Sass compiler that exposes its stdio
+ * streams as Observables.
+ */
+export class SyncEmbeddedCompiler {
+  /** The underlying process that's being wrapped. */
+  private readonly process = new SyncProcess(compilerPath, {windowsHide: true});
+
+  /** The buffers emitted by the child process's stdout. */
+  readonly stdout$ = new Subject<Buffer>();
+
+  /** The buffers emitted by the child process's stderr. */
+  readonly stderr$ = new Subject<Buffer>();
+
+  /** Whether the underlying compiler has already exited. */
+  private exited = false;
+
+  /** Writes `buffer` to the child process's stdin. */
+  writeStdin(buffer: Buffer): void {
+    this.process.stdin.write(buffer);
+  }
+
+  yield(): boolean {
+    const event = this.process.yield();
+    switch (event.type) {
+      case 'stdout':
+        this.stdout$.next(event.data);
+        return true;
+
+      case 'stderr':
+        this.stderr$.next(event.data);
+        return true;
+
+      case 'exit':
+        this.exited = true;
+        return false;
+    }
+  }
+
+  /** Blocks until the underlying process exits. */
+  yieldUntilExit(): void {
+    while (!this.exited) {
+      this.yield();
+    }
+  }
+
+  /** Kills the child process, cleaning up all associated Observables. */
+  close() {
+    this.process.stdin.end();
+  }
+}

--- a/lib/src/sync-process/event.ts
+++ b/lib/src/sync-process/event.ts
@@ -1,0 +1,72 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+/** An event emitted by the child process. */
+export type Event = StdoutEvent | StderrEvent | ExitEvent;
+
+/** An event sent from the worker to the host. */
+export type InternalEvent =
+  | InternalStdoutEvent
+  | InternalStderrEvent
+  | ExitEvent
+  | ErrorEvent;
+
+/** An event indicating that data has been emitted over stdout. */
+export interface StdoutEvent {
+  type: 'stdout';
+  data: Buffer;
+}
+
+/** An event indicating that data has been emitted over stderr. */
+export interface StderrEvent {
+  type: 'stderr';
+  data: Buffer;
+}
+
+/** An event indicating that process has exited. */
+export interface ExitEvent {
+  type: 'exit';
+
+  /**
+   * The exit code. This will be `undefined` if the subprocess was killed via
+   * signal.
+   */
+  code?: number;
+
+  /**
+   * The signal that caused this process to exit. This will be `undefined` if
+   * the subprocess exited normally.
+   */
+  signal?: NodeJS.Signals;
+}
+
+/**
+ * The stdout event sent from the worker to the host. The structured clone
+ * algorithm automatically converts `Buffer`s sent through `MessagePort`s to
+ * `Uint8Array`s.
+ */
+export interface InternalStdoutEvent {
+  type: 'stdout';
+  data: Buffer | Uint8Array;
+}
+
+/**
+ * The stderr event sent from the worker to the host. The structured clone
+ * algorithm automatically converts `Buffer`s sent through `MessagePort`s to
+ * `Uint8Array`s.
+ */
+export interface InternalStderrEvent {
+  type: 'stderr';
+  data: Buffer | Uint8Array;
+}
+
+/**
+ * An error occurred when starting or closing the child process. This is only
+ * used internally; the host will throw the error rather than returning it to
+ * the caller.
+ */
+export interface ErrorEvent {
+  type: 'error';
+  error: Error;
+}

--- a/lib/src/sync-process/index.test.ts
+++ b/lib/src/sync-process/index.test.ts
@@ -1,0 +1,157 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as fs from 'fs';
+import * as p from 'path';
+import * as del from 'del';
+
+import {Event, StderrEvent, StdoutEvent, SyncProcess} from './index';
+
+describe('SyncProcess', () => {
+  describe('stdio', () => {
+    it('emits stdout', () => {
+      withJSProcess('console.log("hello, world!");', node => {
+        expectStdout(node.yield(), 'hello, world!\n');
+      });
+    });
+
+    it('emits stderr', () => {
+      withJSProcess('console.error("hello, world!");', node => {
+        expectStderr(node.yield(), 'hello, world!\n');
+      });
+    });
+
+    it('receives stdin', () => {
+      withJSProcess(
+        'process.stdin.on("data", (data) => process.stdout.write(data));',
+        node => {
+          node.stdin.write('hi there!\n');
+          expectStdout(node.yield(), 'hi there!\n');
+          node.stdin.write('fblthp\n');
+          expectStdout(node.yield(), 'fblthp\n');
+        }
+      );
+    });
+
+    it('closes stdin', () => {
+      withJSProcess(
+        `
+          process.stdin.on("data", () => {});
+          process.stdin.on("end", () => console.log("closed!"));
+        `,
+        node => {
+          node.stdin.end();
+          expectStdout(node.yield(), 'closed!\n');
+        }
+      );
+    });
+  });
+
+  describe('emits exit', () => {
+    it('with code 0 by default', () => {
+      withJSProcess('', node => {
+        expectExit(node.yield(), 0);
+      });
+    });
+
+    it('with a non-0 code', () => {
+      withJSProcess('process.exit(123);', node => {
+        expectExit(node.yield(), 123);
+      });
+    });
+
+    it('with a signal code', () => {
+      withJSProcess('for (;;) {}', node => {
+        node.kill('SIGINT');
+        expectExit(node.yield(), 'SIGINT');
+      });
+    });
+  });
+
+  it('passes options to the subprocess', () => {
+    withJSFile('console.log(process.env.SYNC_PROCESS_TEST);', file => {
+      const node = new SyncProcess(process.argv0, [file], {
+        env: {...process.env, SYNC_PROCESS_TEST: 'abcdef'},
+      });
+      expectStdout(node.yield(), 'abcdef\n');
+      node.kill();
+    });
+  });
+});
+
+/** Asserts that `event` is a `StdoutEvent` with text `text`. */
+function expectStdout(event: Event, text: string): void {
+  if (event.type === 'stderr') {
+    throw `Expected stdout event, was stderr event: ${event.data.toString()}`;
+  }
+
+  expect(event.type).toEqual('stdout');
+  expect((event as StdoutEvent).data.toString()).toEqual(text);
+}
+
+/** Asserts that `event` is a `StderrEvent` with text `text`. */
+function expectStderr(event: Event, text: string): void {
+  if (event.type === 'stdout') {
+    throw `Expected stderr event, was stdout event: ${event.data.toString()}`;
+  }
+
+  expect(event.type).toEqual('stderr');
+  expect((event as StderrEvent).data.toString()).toEqual(text);
+}
+
+/**
+ * Asserts that `event` is an `ExitEvent` with either the given exit code (if
+ * `codeOrSignal` is a number) or signal (if `codeOrSignal` is a string).
+ */
+function expectExit(event: Event, codeOrSignal: number | NodeJS.Signals): void {
+  if (event.type !== 'exit') {
+    throw (
+      `Expected exit event, was ${event.type} event: ` + event.data.toString()
+    );
+  }
+
+  expect(event).toEqual(
+    typeof codeOrSignal === 'number'
+      ? {type: 'exit', code: codeOrSignal}
+      : {type: 'exit', signal: codeOrSignal}
+  );
+}
+
+/**
+ * Starts a `SyncProcess` running a JS file with the given `contents` and passes
+ * it to `callback`.
+ */
+function withJSProcess(
+  contents: string,
+  callback: (process: SyncProcess) => void
+): void {
+  return withJSFile(contents, file => {
+    const node = new SyncProcess(process.argv0, [file]);
+
+    try {
+      callback(node);
+    } finally {
+      node.kill();
+    }
+  });
+}
+
+/**
+ * Creates a JS file with the given `contents` for the duration of `callback`.
+ *
+ * The `callback` is passed the name of the created file.
+ */
+function withJSFile(contents: string, callback: (file: string) => void): void {
+  const testDir = p.join('spec', 'sandbox', `${Math.random()}`.slice(2));
+  fs.mkdirSync(testDir, {recursive: true});
+  const file = p.join(testDir, 'script.js');
+  fs.writeFileSync(file, contents);
+
+  try {
+    callback(file);
+  } finally {
+    // TODO(awjin): Change this to rmSync once we drop support for Node 12.
+    del.sync(testDir, {force: true});
+  }
+}

--- a/lib/src/sync-process/index.ts
+++ b/lib/src/sync-process/index.ts
@@ -1,0 +1,192 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as fs from 'fs';
+import * as p from 'path';
+import * as stream from 'stream';
+import {Worker, WorkerOptions} from 'worker_threads';
+
+import {SyncMessagePort} from './sync-message-port';
+import {Event, InternalEvent} from './event';
+
+export {Event, ExitEvent, StderrEvent, StdoutEvent} from './event';
+
+// TODO(nex3): Factor this out into its own package.
+
+/**
+ * A child process that runs synchronously while also allowing the user to
+ * interact with it before it shuts down.
+ */
+export class SyncProcess {
+  /** The port that communicates with the worker thread. */
+  private readonly port: SyncMessagePort;
+
+  /** The worker in which the child process runs. */
+  private readonly worker: Worker;
+
+  /** The standard input stream to write to the process. */
+  readonly stdin: stream.Writable;
+
+  /** Creates a new synchronous process running `command` with `args`. */
+  constructor(command: string, options?: Options);
+  constructor(command: string, args: string[], options?: Options);
+
+  constructor(
+    command: string,
+    argsOrOptions?: string[] | Options,
+    options?: Options
+  ) {
+    let args: string[];
+    if (Array.isArray(argsOrOptions)) {
+      args = argsOrOptions;
+    } else {
+      args = [];
+      options = argsOrOptions;
+    }
+
+    const {port1, port2} = SyncMessagePort.createChannel();
+    this.port = new SyncMessagePort(port1);
+
+    this.worker = spawnWorker(p.join(p.dirname(__filename), 'worker'), {
+      workerData: {port: port2, command, args, options},
+      transferList: [port2],
+    });
+
+    // The worker shouldn't emit any errors unless it breaks in development.
+    this.worker.on('error', console.error);
+
+    this.stdin = new stream.Writable({
+      write: (chunk: Buffer, encoding, callback) => {
+        this.port.postMessage(
+          {
+            type: 'stdin',
+            data: chunk as Buffer,
+          },
+          [chunk.buffer]
+        );
+        callback();
+      },
+    });
+
+    // Unfortunately, there's no built-in event or callback that will reliably
+    // *synchronously* notify us that the stdin stream has been closed. (The
+    // `final` callback works in Node v16 but not v14.) Instead, we wrap the
+    // methods themselves that are used to close the stream.
+    const oldEnd = this.stdin.end.bind(this.stdin) as (
+      a1?: unknown,
+      a2?: unknown,
+      a3?: unknown
+    ) => void;
+    this.stdin.end = ((a1?: unknown, a2?: unknown, a3?: unknown) => {
+      oldEnd(a1, a2, a3);
+      this.port.postMessage({type: 'stdinClosed'});
+    }) as typeof this.stdin.end;
+
+    const oldDestroy = this.stdin.destroy.bind(this.stdin) as (
+      a1?: unknown
+    ) => void;
+    this.stdin.destroy = ((a1?: unknown) => {
+      oldDestroy(a1);
+      this.port.postMessage({type: 'stdinClosed'});
+    }) as typeof this.stdin.destroy;
+  }
+
+  /**
+   * Blocks until the child process is ready to emit another event, then returns
+   * that event.
+   *
+   * If there's an error running the child process, this will throw that error.
+   * This may not be called after it emits an `ExitEvent` or throws an error.
+   */
+  yield(): Event {
+    if (this.stdin.destroyed) {
+      throw new Error(
+        "Can't call SyncProcess.yield() after the process has exited."
+      );
+    }
+
+    const message = this.port.receiveMessage() as InternalEvent;
+    switch (message.type) {
+      case 'stdout':
+        return {type: 'stdout', data: Buffer.from(message.data.buffer)};
+
+      case 'stderr':
+        return {type: 'stderr', data: Buffer.from(message.data.buffer)};
+
+      case 'error':
+        this.close();
+        throw message.error;
+
+      case 'exit':
+        this.close();
+        return message;
+    }
+  }
+
+  // TODO(nex3): Add a non-blocking `yieldIfReady()` function that returns
+  // `null` if the worker hasn't queued up an event.
+
+  // TODO(nex3): Add a `yieldAsync()` function that returns a `Promise<Event>`.
+
+  /**
+   * Sends a signal (`SIGTERM` by default) to the child process.
+   *
+   * This has no effect if the process has already exited.
+   */
+  kill(signal?: NodeJS.Signals | number): void {
+    this.port.postMessage({type: 'kill', signal});
+  }
+
+  /** Closes down the worker thread and the stdin stream. */
+  private close(): void {
+    this.port.close();
+    this.worker.terminate();
+    this.stdin.destroy();
+  }
+}
+
+/**
+ * Spawns a worker for the given `fileWithoutExtension` in either a JS or TS
+ * worker, depending on which file exists.
+ */
+function spawnWorker(
+  fileWithoutExtension: string,
+  options: WorkerOptions
+): Worker {
+  // The released version always spawns the JS worker. The TS worker is only
+  // used for development.
+  const jsFile = fileWithoutExtension + '.js';
+  if (fs.existsSync(jsFile)) return new Worker(jsFile, options);
+
+  const tsFile = fileWithoutExtension + '.ts';
+  if (fs.existsSync(tsFile)) {
+    return new Worker(
+      `
+        require('ts-node').register();
+        require(${JSON.stringify(tsFile)});
+      `,
+      {...options, eval: true}
+    );
+  }
+
+  throw new Error(`Neither "${jsFile}" nor ".ts" exists.`);
+}
+
+/**
+ * A subset of the options for [`child_process.spawn()`].
+ *
+ * [`child_process.spawn()`]: https://nodejs.org/api/child_process.html#child_processspawncommand-args-options
+ */
+export interface Options {
+  cwd?: string;
+  env?: Record<string, string>;
+  argv0?: string;
+  uid?: number;
+  gid?: number;
+  shell?: boolean | string;
+  windowsVerbatimArguments?: boolean;
+  windowsHide?: boolean;
+  timeout?: number;
+  killSignal?: string | number;
+}

--- a/lib/src/sync-process/sync-message-port.test.ts
+++ b/lib/src/sync-process/sync-message-port.test.ts
@@ -1,0 +1,160 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as fs from 'fs';
+import * as p from 'path';
+import {MessagePort, Worker} from 'worker_threads';
+
+import {SyncMessagePort} from './sync-message-port';
+
+describe('SyncMessagePort', () => {
+  describe('sends a message', () => {
+    it('before the other endpoint calls receiveMessage()', () => {
+      const channel = SyncMessagePort.createChannel();
+      const port1 = new SyncMessagePort(channel.port1);
+      port1.postMessage('hi there!');
+
+      const port2 = new SyncMessagePort(channel.port2);
+      expect(port2.receiveMessage()).toEqual('hi there!');
+    });
+
+    it('after the other endpoint calls receiveMessage()', () => {
+      const channel = SyncMessagePort.createChannel();
+      const port = new SyncMessagePort(channel.port1);
+
+      spawnWorker(
+        `
+        // Wait a little bit just to make entirely sure that the parent thread
+        // is awaiting a message.
+        setTimeout(() => {
+          port.postMessage('done!');
+          port.close();
+        }, 100);
+      `,
+        channel.port2
+      );
+
+      expect(port.receiveMessage()).toEqual('done!');
+    });
+
+    it('multiple times before the other endpoint starts reading', () => {
+      const channel = SyncMessagePort.createChannel();
+      const port1 = new SyncMessagePort(channel.port1);
+      port1.postMessage('message1');
+      port1.postMessage('message2');
+      port1.postMessage('message3');
+      port1.postMessage('message4');
+
+      const port2 = new SyncMessagePort(channel.port2);
+      expect(port2.receiveMessage()).toEqual('message1');
+      expect(port2.receiveMessage()).toEqual('message2');
+      expect(port2.receiveMessage()).toEqual('message3');
+      expect(port2.receiveMessage()).toEqual('message4');
+    });
+  });
+
+  describe('with an asynchronous listener', () => {
+    it('receives a message sent before listening', async () => {
+      const channel = SyncMessagePort.createChannel();
+      const port1 = new SyncMessagePort(channel.port1);
+      port1.postMessage('hi there!');
+
+      const port2 = new SyncMessagePort(channel.port2);
+
+      // Wait a macrotask to make sure the message is as queued up as it's going
+      // to be.
+      await new Promise(process.nextTick);
+
+      const promise = new Promise(resolve => port2.once('message', resolve));
+      await expect(promise).resolves.toEqual('hi there!');
+      port1.close();
+    });
+
+    it('receives a message sent after listening', async () => {
+      const channel = SyncMessagePort.createChannel();
+      const port1 = new SyncMessagePort(channel.port1);
+      const promise = new Promise(resolve => port1.once('message', resolve));
+
+      // Wait a macrotask to make sure the message is as queued up as it's going
+      // to be.
+      await new Promise(process.nextTick);
+      const port2 = new SyncMessagePort(channel.port2);
+      port2.postMessage('hi there!');
+
+      await expect(promise).resolves.toEqual('hi there!');
+      port1.close();
+    });
+
+    it('receiveMessage() throws an error after listening', async () => {
+      const channel = SyncMessagePort.createChannel();
+      const port1 = new SyncMessagePort(channel.port1);
+      port1.on('message', () => {});
+
+      expect(port1.receiveMessage).toThrow();
+      port1.close();
+    });
+  });
+
+  describe('close()', () => {
+    it('closing one port closes the other', async () => {
+      const channel = SyncMessagePort.createChannel();
+      const port1 = new SyncMessagePort(channel.port1);
+      const port2 = new SyncMessagePort(channel.port2);
+
+      port1.close();
+
+      // Should resolve.
+      await new Promise(resolve => port2.once('close', resolve));
+    });
+
+    it('receiveMessage() throws an error for a closed port', () => {
+      const channel = SyncMessagePort.createChannel();
+      const port1 = new SyncMessagePort(channel.port1);
+      const port2 = new SyncMessagePort(channel.port2);
+
+      port1.close();
+      expect(port1.receiveMessage).toThrow();
+      expect(port2.receiveMessage).toThrow();
+    });
+  });
+});
+
+/**
+ * Spawns a worker that executes the given TypeScript `source`.
+ *
+ * Automatically initializes a `SyncMessageChannel` named `port` connected to
+ * `port`.
+ */
+function spawnWorker(source: string, port: MessagePort): Worker {
+  fs.mkdirSync('spec/sandbox', {recursive: true});
+  const file = p.join('spec/sandbox', `${Math.random()}.ts`.slice(2));
+  fs.writeFileSync(
+    file,
+    `
+    const {SyncMessagePort} = require(${JSON.stringify(
+      p.join(p.dirname(__filename), 'sync-message-port')
+    )});
+    const {workerData} = require('worker_threads');
+
+    const port = new SyncMessagePort(workerData);
+
+    ${source}
+  `
+  );
+
+  const worker = new Worker(
+    `
+      require('ts-node').register();
+      require(${JSON.stringify(p.resolve(file.substring(0, file.length - 3)))});
+    `,
+    {eval: true, workerData: port, transferList: [port]}
+  );
+
+  worker.on('error', error => {
+    throw error;
+  });
+  worker.on('exit', () => fs.unlinkSync(file));
+
+  return worker;
+}

--- a/lib/src/sync-process/sync-message-port.ts
+++ b/lib/src/sync-process/sync-message-port.ts
@@ -1,0 +1,170 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {strict as assert} from 'assert';
+import {EventEmitter} from 'events';
+import {
+  receiveMessageOnPort,
+  MessageChannel,
+  MessagePort,
+  TransferListItem,
+} from 'worker_threads';
+
+// TODO(nex3): Make this its own package.
+
+/**
+ * An enum of possible states for the shared buffer that two `SyncMessagePort`s
+ * use to communicate.
+ */
+enum BufferState {
+  /**
+   * The initial state. When an endpoint is ready to receive messages, it'll set
+   * the buffer to this state so that it can use `Atomics.wait()` to be notified
+   * when it switches to `MessageSent`.
+   */
+  AwaitingMessage,
+  /**
+   * The state indicating that a message has been sent. Whenever an endpoint
+   * sends a message, it'll set the buffer to this state so that the other
+   * endpoint's `Atomics.wait()` call terminates.
+   */
+  MessageSent,
+  /**
+   * The state indicating that the channel has been closed. This never
+   * transitions to any other states.
+   */
+  Closed,
+}
+
+/**
+ * A communication port that can receive messages synchronously from another
+ * `SyncMessagePort`.
+ *
+ * This also emits the same asynchronous events as `MessagePort`.
+ */
+export class SyncMessagePort extends EventEmitter {
+  /** Creates a channel whose ports can be passed to `new SyncMessagePort()`. */
+  static createChannel(): MessageChannel {
+    const channel = new MessageChannel();
+    // Four bytes is the minimum necessary to use `Atomics.wait()`.
+    const buffer = new SharedArrayBuffer(4);
+
+    // Queue up messages on each port so the caller doesn't have to explicitly
+    // pass the buffer around along with them.
+    channel.port1.postMessage(buffer);
+    channel.port2.postMessage(buffer);
+    return channel;
+  }
+
+  /**
+   * An Int32 view of the shared buffer.
+   *
+   * Each port sets this to `BufferState.AwaitingMessage` before checking for
+   * new messages in `receiveMessage()`, and each port sets it to
+   * `BufferState.MessageSent` after sending a new message. It's set to
+   * `BufferState.Closed` when the channel is closed.
+   */
+  private readonly buffer: Int32Array;
+
+  /**
+   * Creates a new message port. The `port` must be created by
+   * `SyncMessagePort.createChannel()` and must connect to a port passed to
+   * another `SyncMessagePort` in another worker.
+   */
+  constructor(private readonly port: MessagePort) {
+    super();
+
+    const buffer = receiveMessageOnPort(this.port)?.message;
+    if (!buffer) {
+      throw new Error(
+        'new SyncMessagePort() must be passed a port from ' +
+          'SyncMessagePort.createChannel().'
+      );
+    }
+    this.buffer = new Int32Array(buffer as SharedArrayBuffer);
+
+    this.on('newListener', (event, listener) => {
+      this.port.on(event, listener);
+    });
+    this.on('removeListener', (event, listener) =>
+      this.port.removeListener(event, listener)
+    );
+  }
+
+  /** See `MessagePort.postMesage()`. */
+  postMessage(value: unknown, transferList?: TransferListItem[]): void {
+    this.port.postMessage(value, transferList);
+
+    // If the other port is waiting for a new message, notify it that the
+    // message is ready. Use `Atomics.compareExchange` so that we don't
+    // overwrite the "closed" state.
+    if (
+      Atomics.compareExchange(
+        this.buffer,
+        0,
+        BufferState.AwaitingMessage,
+        BufferState.MessageSent
+      ) === BufferState.AwaitingMessage
+    ) {
+      Atomics.notify(this.buffer, 0);
+    }
+  }
+
+  // TODO(nex3):
+  // * Add a non-blocking `receiveMessage()`
+  // * Add a timeout option to `receiveMessage()`
+  // * Add an option to `receiveMessage()` to return a special value if the
+  //   channel is closed.
+
+  /**
+   * Blocks and returns the next message sent by the other port.
+   *
+   * This may not be called while this has a listener for the `'message'` event.
+   * Throws an error if the channel is closed, including if it closes while this
+   * is waiting for a message.
+   */
+  receiveMessage(): unknown {
+    if (this.listenerCount('message')) {
+      throw new Error(
+        'SyncMessageChannel.receiveMessage() may not be called while there ' +
+          'are message listeners.'
+      );
+    }
+
+    // Set the "new message" indicator to zero before we check for new messages.
+    // That way if the other port sets it to 1 between the call to
+    // `receiveMessageOnPort` and the call to `Atomics.wait()`, we won't
+    // overwrite it. Use `Atomics.compareExchange` so that we don't overwrite
+    // the "closed" state.
+    if (
+      Atomics.compareExchange(
+        this.buffer,
+        0,
+        BufferState.MessageSent,
+        BufferState.AwaitingMessage
+      ) === BufferState.Closed
+    ) {
+      throw new Error("The SyncMessagePort's channel is closed.");
+    }
+
+    let message = receiveMessageOnPort(this.port);
+    if (message) return message.message;
+
+    // If there's no new message, wait for the other port to flip the "new
+    // message" indicator to 1. If it's been set to 1 since we stored 0, this
+    // will terminate immediately.
+    Atomics.wait(this.buffer, 0, BufferState.AwaitingMessage);
+    message = receiveMessageOnPort(this.port);
+    if (message) return message.message;
+
+    assert.equal(Atomics.load(this.buffer, 0), BufferState.Closed);
+    throw new Error("The SyncMessagePort's channel is closed.");
+  }
+
+  /** See `MessagePort.close()`. */
+  close(): void {
+    Atomics.store(this.buffer, 0, BufferState.Closed);
+    this.port.close();
+  }
+}

--- a/lib/src/sync-process/worker.ts
+++ b/lib/src/sync-process/worker.ts
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {
+  parentPort,
+  workerData,
+  MessagePort,
+  TransferListItem,
+} from 'worker_threads';
+import {spawn, SpawnOptionsWithoutStdio} from 'child_process';
+import {strict as assert} from 'assert';
+
+import {SyncMessagePort} from './sync-message-port';
+import {InternalEvent} from './event';
+
+const port = new SyncMessagePort(workerData.port as MessagePort);
+
+/** A more type-safe way to call `port.postMesage()` */
+function emit(event: InternalEvent, transferList?: TransferListItem[]): void {
+  port.postMessage(event, transferList);
+}
+
+const process = spawn(
+  workerData.command as string,
+  workerData.args as string[],
+  workerData.options as SpawnOptionsWithoutStdio | undefined
+);
+
+port.on('message', message => {
+  if (message.type === 'stdin') {
+    process.stdin.write(message.data as Buffer);
+  } else if (message.type === 'stdinClosed') {
+    process.stdin.end();
+  } else {
+    assert.equal(message.type, 'kill');
+    process.kill(message.signal as number | NodeJS.Signals | undefined);
+  }
+});
+
+process.stdout.on('data', data => {
+  emit({type: 'stdout', data}, [data.buffer]);
+});
+
+process.stderr.on('data', data => {
+  emit({type: 'stderr', data}, [data.buffer]);
+});
+
+process.on('error', error => {
+  emit({type: 'error', error});
+
+  process.kill();
+  parentPort!.close();
+  port.close();
+});
+
+process.on('exit', (code, signal) => {
+  if (code !== null) {
+    emit({type: 'exit', code});
+  } else {
+    assert(signal);
+    emit({type: 'exit', signal});
+  }
+
+  parentPort!.close();
+  port.close();
+});

--- a/lib/src/utils.test.ts
+++ b/lib/src/utils.test.ts
@@ -1,0 +1,37 @@
+import {pathToFileURL} from 'url';
+import {pathToUrlString} from './utils';
+
+describe('utils', () => {
+  describe('pathToUrlString', () => {
+    it('encode relative path like `pathToFileURL`', () => {
+      const baseURL = pathToFileURL('').toString();
+      for (let i = 0; i < 128; i++) {
+        const char = String.fromCharCode(i);
+        const filename = `${i}-${char}`;
+        expect(pathToUrlString(filename)).toEqual(
+          pathToFileURL(filename)
+            .toString()
+            .slice(baseURL.length + 1)
+        );
+      }
+    });
+
+    it('encode percent encoded string like `pathToFileURL`', () => {
+      const baseURL = pathToFileURL('').toString();
+      for (let i = 0; i < 128; i++) {
+        const lowercase = `%${i < 10 ? '0' : ''}${i.toString(16)}`;
+        expect(pathToUrlString(lowercase)).toEqual(
+          pathToFileURL(lowercase)
+            .toString()
+            .slice(baseURL.length + 1)
+        );
+        const uppercase = lowercase.toUpperCase();
+        expect(pathToUrlString(uppercase)).toEqual(
+          pathToFileURL(uppercase)
+            .toString()
+            .slice(baseURL.length + 1)
+        );
+      }
+    });
+  });
+});

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -1,0 +1,166 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {List} from 'immutable';
+import * as p from 'path';
+import * as url from 'url';
+
+import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import {Syntax} from './vendor/sass';
+
+export type PromiseOr<
+  T,
+  sync extends 'sync' | 'async' = 'async'
+> = sync extends 'async' ? T | Promise<T> : T;
+
+// A boolean type that's `true` if `sync` requires synchronous APIs only and
+// `false` if it allows asynchronous APIs.
+export type SyncBoolean<sync extends 'sync' | 'async'> = sync extends 'async'
+  ? false
+  : true;
+
+/**
+ * The equivalent of `Promise.then()`, except that if the first argument is a
+ * plain value it synchronously invokes `callback()` and returns its result.
+ */
+export function thenOr<T, V, sync extends 'sync' | 'async'>(
+  promiseOrValue: PromiseOr<T, sync>,
+  callback: (value: T) => PromiseOr<V, sync>
+): PromiseOr<V, sync> {
+  return promiseOrValue instanceof Promise
+    ? (promiseOrValue.then(callback) as PromiseOr<V, sync>)
+    : callback(promiseOrValue as T);
+}
+
+/**
+ * The equivalent of `Promise.catch()`, except that if the first argument throws
+ * synchronously it synchronously invokes `callback()` and returns its result.
+ */
+export function catchOr<T, sync extends 'sync' | 'async'>(
+  promiseOrValueCallback: () => PromiseOr<T, sync>,
+  callback: (error: unknown) => PromiseOr<T, sync>
+): PromiseOr<T, sync> {
+  try {
+    const result = promiseOrValueCallback();
+    return result instanceof Promise
+      ? (result.catch(callback) as PromiseOr<T, sync>)
+      : result;
+  } catch (error: unknown) {
+    return callback(error);
+  }
+}
+
+/** Checks for null or undefined. */
+export function isNullOrUndefined<T>(
+  object: T | null | undefined
+): object is null | undefined {
+  return object === null || object === undefined;
+}
+
+/** Returns `collection` as an immutable List. */
+export function asImmutableList<T>(collection: T[] | List<T>): List<T> {
+  return List.isList(collection) ? collection : List(collection);
+}
+
+/** Constructs a compiler-caused Error. */
+export function compilerError(message: string): Error {
+  return Error(`Compiler caused error: ${message}.`);
+}
+
+/**
+ * Returns a `compilerError()` indicating that the given `field` should have
+ * been included but was not.
+ */
+export function mandatoryError(field: string): Error {
+  return compilerError(`Missing mandatory field ${field}`);
+}
+
+/** Constructs a host-caused Error. */
+export function hostError(message: string): Error {
+  return Error(`Compiler reported error: ${message}.`);
+}
+
+/** Constructs an error caused by an invalid value type. */
+export function valueError(message: string, name?: string): Error {
+  return Error(name ? `$${name}: ${message}.` : `${message}.`);
+}
+
+/** Converts a (possibly relative) path on the local filesystem to a URL. */
+export function pathToUrlString(path: string): string {
+  if (p.isAbsolute(path)) return url.pathToFileURL(path).toString();
+
+  // percent encode relative path like `pathToFileURL`
+  return encodeURI(path)
+    .replace(/[#?]/g, encodeURIComponent)
+    .replace(
+      process.platform === 'win32' ? /%(5B|5C|5D|5E|7C)/g : /%(5B|5D|5E|7C)/g,
+      decodeURIComponent
+    )
+    .replace(/\\/g, '/');
+}
+
+/**
+ * Like `url.fileURLToPath`, but returns the same result for Windows-style file
+ * URLs on all platforms.
+ */
+export function fileUrlToPathCrossPlatform(fileUrl: url.URL | string): string {
+  const path = url.fileURLToPath(fileUrl);
+
+  // Windows file: URLs begin with `file:///C:/` (or another drive letter),
+  // which `fileURLToPath` converts to `"/C:/"` on non-Windows systems. We want
+  // to ensure the behavior is consistent across OSes, so we normalize this back
+  // to a Windows-style path.
+  return /^\/[A-Za-z]:\//.test(path) ? path.substring(1) : path;
+}
+
+/** Returns `path` without an extension, if it had one. */
+export function withoutExtension(path: string): string {
+  const extension = p.extname(path);
+  return path.substring(0, path.length - extension.length);
+}
+
+/** Converts a JS syntax string into a protobuf syntax enum. */
+export function protofySyntax(
+  syntax: Syntax
+): proto.SyntaxMap[keyof proto.SyntaxMap] {
+  switch (syntax) {
+    case 'scss':
+      return proto.Syntax.SCSS;
+
+    case 'indented':
+      return proto.Syntax.INDENTED;
+
+    case 'css':
+      return proto.Syntax.CSS;
+
+    default:
+      throw new Error(`Unknown syntax: "${syntax}"`);
+  }
+}
+
+/** Returns whether `error` is a NodeJS-style exception with an error code. */
+export function isErrnoException(
+  error: unknown
+): error is NodeJS.ErrnoException {
+  return error instanceof Error && ('errno' in error || 'code' in error);
+}
+
+/**
+ * Dart-style utility. See
+ * http://go/dart-api/stable/2.8.4/dart-core/Map/putIfAbsent.html.
+ */
+export function putIfAbsent<K, V>(
+  map: Map<K, V>,
+  key: K,
+  provider: () => V
+): V {
+  const val = map.get(key);
+  if (val !== undefined) {
+    return val;
+  } else {
+    const newVal = provider();
+    map.set(key, newVal);
+    return newVal;
+  }
+}

--- a/lib/src/value/argument-list.ts
+++ b/lib/src/value/argument-list.ts
@@ -1,0 +1,60 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {isOrderedMap, List, OrderedMap} from 'immutable';
+
+import {ListSeparator, SassList} from './list';
+import {Value} from './index';
+
+export class SassArgumentList extends SassList {
+  /**
+   * The `FunctionCallRequest`-scoped ID of this argument list, used to tell the
+   * compiler which argument lists have had their keywords accessed during a
+   * function call.
+   *
+   * The special ID 0 indicates an argument list constructed in the host.
+   *
+   * This is marked as public so that the protofier can access it, but it's not
+   * part of the package's public API and should not be accessed by user code.
+   * It may be renamed or removed without warning in the future.
+   */
+  readonly id: number;
+
+  /**
+   * The argument list's keywords. This isn't exposed directly so that we can
+   * set `keywordsAccessed` when the user reads it.
+   *
+   * This is marked as public so that the protofier can access it, but it's not
+   * part of the package's public API and should not be accessed by user code.
+   * It may be renamed or removed without warning in the future.
+   */
+  readonly keywordsInternal: OrderedMap<string, Value>;
+
+  /**
+   * Whether the `keywords` getter has been accessed.
+   *
+   * This is marked as public so that the protofier can access it, but it's not
+   * part of the package's public API and should not be accessed by user code.
+   * It may be renamed or removed without warning in the future.
+   */
+  keywordsAccessed = false;
+
+  get keywords(): OrderedMap<string, Value> {
+    this.keywordsAccessed = true;
+    return this.keywordsInternal;
+  }
+
+  constructor(
+    contents: Value[] | List<Value>,
+    keywords: Record<string, Value> | OrderedMap<string, Value>,
+    separator?: ListSeparator,
+    id?: number
+  ) {
+    super(contents, {separator});
+    this.keywordsInternal = isOrderedMap(keywords)
+      ? keywords
+      : OrderedMap(keywords);
+    this.id = id ?? 0;
+  }
+}

--- a/lib/src/value/boolean.ts
+++ b/lib/src/value/boolean.ts
@@ -1,0 +1,85 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {hash} from 'immutable';
+
+import {Value} from './index';
+
+/**
+ * Sass boolean.
+ *
+ * Cannot be constructed; exists only as an interface and the exported
+ * singletons.
+ */
+export interface SassBoolean extends Value {
+  readonly value: boolean;
+}
+
+const trueHash = hash(true);
+const falseHash = hash(false);
+
+export class SassBooleanInternal extends Value implements SassBoolean {
+  // Whether callers are allowed to construct this class. This is set to
+  // `false` once the two constants are constructed so that the constructor
+  // throws an error for future calls, in accordance with the legacy API.
+  static constructionAllowed = true;
+
+  constructor(private readonly valueInternal: boolean) {
+    super();
+
+    if (!SassBooleanInternal.constructionAllowed) {
+      throw (
+        "new sass.types.Boolean() isn't allowed.\n" +
+        'Use sass.types.Boolean.TRUE or sass.types.Boolean.FALSE instead.'
+      );
+    }
+
+    Object.freeze(this);
+  }
+
+  get value(): boolean {
+    return this.valueInternal;
+  }
+
+  get isTruthy(): boolean {
+    return this.value;
+  }
+
+  assertBoolean(): SassBoolean {
+    return this;
+  }
+
+  equals(other: Value): boolean {
+    return this === other;
+  }
+
+  hashCode(): number {
+    return this.value ? trueHash : falseHash;
+  }
+
+  toString(): string {
+    return this.value ? 'sassTrue' : 'sassFalse';
+  }
+
+  // Legacy API support
+
+  static TRUE: SassBooleanInternal;
+  static FALSE: SassBooleanInternal;
+
+  getValue(): boolean {
+    return this.value;
+  }
+}
+
+/** The singleton instance of SassScript true. */
+export const sassTrue = new SassBooleanInternal(true);
+
+/** The singleton instance of SassScript false. */
+export const sassFalse = new SassBooleanInternal(false);
+
+// Legacy API support
+SassBooleanInternal.constructionAllowed = false;
+
+SassBooleanInternal.TRUE = sassTrue;
+SassBooleanInternal.FALSE = sassFalse;

--- a/lib/src/value/color.ts
+++ b/lib/src/value/color.ts
@@ -1,0 +1,373 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {Value} from './index';
+import {
+  fuzzyAssertInRange,
+  fuzzyEquals,
+  fuzzyRound,
+  positiveMod,
+} from './utils';
+import {hash} from 'immutable';
+
+interface RgbColor {
+  red: number;
+  green: number;
+  blue: number;
+  alpha?: number;
+}
+
+interface HslColor {
+  hue: number;
+  saturation: number;
+  lightness: number;
+  alpha?: number;
+}
+
+interface HwbColor {
+  hue: number;
+  whiteness: number;
+  blackness: number;
+  alpha?: number;
+}
+
+/** A SassScript color. */
+export class SassColor extends Value {
+  private redInternal?: number;
+  private greenInternal?: number;
+  private blueInternal?: number;
+  private hueInternal?: number;
+  private saturationInternal?: number;
+  private lightnessInternal?: number;
+  private readonly alphaInternal: number;
+
+  constructor(color: RgbColor);
+  constructor(color: HslColor);
+  constructor(color: HwbColor);
+  constructor(color: RgbColor | HslColor | HwbColor) {
+    super();
+
+    if ('red' in color) {
+      this.redInternal = fuzzyAssertInRange(
+        Math.round(color.red),
+        0,
+        255,
+        'red'
+      );
+      this.greenInternal = fuzzyAssertInRange(
+        Math.round(color.green),
+        0,
+        255,
+        'green'
+      );
+      this.blueInternal = fuzzyAssertInRange(
+        Math.round(color.blue),
+        0,
+        255,
+        'blue'
+      );
+    } else if ('saturation' in color) {
+      this.hueInternal = positiveMod(color.hue, 360);
+      this.saturationInternal = fuzzyAssertInRange(
+        color.saturation,
+        0,
+        100,
+        'saturation'
+      );
+      this.lightnessInternal = fuzzyAssertInRange(
+        color.lightness,
+        0,
+        100,
+        'lightness'
+      );
+    } else {
+      // From https://www.w3.org/TR/css-color-4/#hwb-to-rgb
+      const scaledHue = positiveMod(color.hue, 360) / 360;
+      let scaledWhiteness =
+        fuzzyAssertInRange(color.whiteness, 0, 100, 'whiteness') / 100;
+      let scaledBlackness =
+        fuzzyAssertInRange(color.blackness, 0, 100, 'blackness') / 100;
+
+      const sum = scaledWhiteness + scaledBlackness;
+      if (sum > 1) {
+        scaledWhiteness /= sum;
+        scaledBlackness /= sum;
+      }
+
+      // Because HWB is (currently) used much less frequently than HSL or RGB, we
+      // don't cache its values because we expect the memory overhead of doing so
+      // to outweigh the cost of recalculating it on access. Instead, we eagerly
+      // convert it to RGB and then convert back if necessary.
+      this.redInternal = hwbToRgb(
+        scaledHue + 1 / 3,
+        scaledWhiteness,
+        scaledBlackness
+      );
+      this.greenInternal = hwbToRgb(
+        scaledHue,
+        scaledWhiteness,
+        scaledBlackness
+      );
+      this.blueInternal = hwbToRgb(
+        scaledHue - 1 / 3,
+        scaledWhiteness,
+        scaledBlackness
+      );
+    }
+
+    this.alphaInternal =
+      color.alpha === undefined
+        ? 1
+        : fuzzyAssertInRange(color.alpha, 0, 1, 'alpha');
+  }
+
+  /** `this`'s red channel. */
+  get red(): number {
+    if (this.redInternal === undefined) {
+      this.hslToRgb();
+    }
+    return this.redInternal!;
+  }
+
+  /** `this`'s blue channel. */
+  get blue(): number {
+    if (this.blueInternal === undefined) {
+      this.hslToRgb();
+    }
+    return this.blueInternal!;
+  }
+
+  /** `this`'s green channel. */
+  get green(): number {
+    if (this.greenInternal === undefined) {
+      this.hslToRgb();
+    }
+    return this.greenInternal!;
+  }
+
+  /** `this`'s hue value. */
+  get hue(): number {
+    if (this.hueInternal === undefined) {
+      this.rgbToHsl();
+    }
+    return this.hueInternal!;
+  }
+
+  /** `this`'s saturation value. */
+  get saturation(): number {
+    if (this.saturationInternal === undefined) {
+      this.rgbToHsl();
+    }
+    return this.saturationInternal!;
+  }
+
+  /** `this`'s hue value. */
+  get lightness(): number {
+    if (this.lightnessInternal === undefined) {
+      this.rgbToHsl();
+    }
+    return this.lightnessInternal!;
+  }
+
+  /** `this`'s whiteness value. */
+  get whiteness(): number {
+    // Because HWB is (currently) used much less frequently than HSL or RGB, we
+    // don't cache its values because we expect the memory overhead of doing so
+    // to outweigh the cost of recalculating it on access.
+    return (Math.min(this.red, this.green, this.blue) / 255) * 100;
+  }
+
+  /** `this`'s blackness value. */
+  get blackness(): number {
+    // Because HWB is (currently) used much less frequently than HSL or RGB, we
+    // don't cache its values because we expect the memory overhead of doing so
+    // to outweigh the cost of recalculating it on access.
+    return 100 - (Math.max(this.red, this.green, this.blue) / 255) * 100;
+  }
+
+  /** `this`'s alpha channel. */
+  get alpha(): number {
+    return this.alphaInternal;
+  }
+
+  /**
+   * Whether `this` has already calculated the HSL components for the color.
+   *
+   * This is an internal property that's not an official part of Sass's JS API,
+   * and may be broken at any time.
+   */
+  get hasCalculatedHsl(): boolean {
+    return !!this.hueInternal;
+  }
+
+  assertColor(): SassColor {
+    return this;
+  }
+
+  /**
+   * Returns a copy of `this` with its channels changed to match `color`.
+   */
+  change(color: Partial<RgbColor>): SassColor;
+  change(color: Partial<HslColor>): SassColor;
+  change(color: Partial<HwbColor>): SassColor;
+  change(
+    color: Partial<RgbColor> | Partial<HslColor> | Partial<HwbColor>
+  ): SassColor {
+    if ('whiteness' in color || 'blackness' in color) {
+      return new SassColor({
+        hue: color.hue ?? this.hue,
+        whiteness: color.whiteness ?? this.whiteness,
+        blackness: color.blackness ?? this.blackness,
+        alpha: color.alpha ?? this.alpha,
+      });
+    } else if (
+      'hue' in color ||
+      'saturation' in color ||
+      'lightness' in color
+    ) {
+      // Tell TypeScript this isn't a Partial<HwbColor>.
+      const hsl = color as Partial<HslColor>;
+      return new SassColor({
+        hue: hsl.hue ?? this.hue,
+        saturation: hsl.saturation ?? this.saturation,
+        lightness: hsl.lightness ?? this.lightness,
+        alpha: hsl.alpha ?? this.alpha,
+      });
+    } else if (
+      'red' in color ||
+      'green' in color ||
+      'blue' in color ||
+      this.redInternal
+    ) {
+      const rgb = color as Partial<RgbColor>;
+      return new SassColor({
+        red: rgb.red ?? this.red,
+        green: rgb.green ?? this.green,
+        blue: rgb.blue ?? this.blue,
+        alpha: rgb.alpha ?? this.alpha,
+      });
+    } else {
+      return new SassColor({
+        hue: this.hue,
+        saturation: this.saturation,
+        lightness: this.lightness,
+        alpha: color.alpha ?? this.alpha,
+      });
+    }
+  }
+
+  equals(other: Value): boolean {
+    return (
+      other instanceof SassColor &&
+      fuzzyEquals(this.red, other.red) &&
+      fuzzyEquals(this.green, other.green) &&
+      fuzzyEquals(this.blue, other.blue) &&
+      fuzzyEquals(this.alpha, other.alpha)
+    );
+  }
+
+  hashCode(): number {
+    return hash(this.red ^ this.green ^ this.blue ^ this.alpha);
+  }
+
+  toString(): string {
+    const isOpaque = fuzzyEquals(this.alpha, 1);
+    let string = isOpaque ? 'rgb(' : 'rgba(';
+    string += `${this.red}, ${this.green}, ${this.blue}`;
+    string += isOpaque ? ')' : `, ${this.alpha})`;
+    return string;
+  }
+
+  // Computes `this`'s `hue`, `saturation`, and `lightness` values based on
+  // `red`, `green`, and `blue`.
+  //
+  // Algorithm from https://en.wikipedia.org/wiki/HSL_and_HSV#RGB_to_HSL_and_HSV
+  private rgbToHsl(): void {
+    const scaledRed = this.red / 255;
+    const scaledGreen = this.green / 255;
+    const scaledBlue = this.blue / 255;
+
+    const max = Math.max(scaledRed, scaledGreen, scaledBlue);
+    const min = Math.min(scaledRed, scaledGreen, scaledBlue);
+    const delta = max - min;
+
+    if (max === min) {
+      this.hueInternal = 0;
+    } else if (max === scaledRed) {
+      this.hueInternal = positiveMod(
+        (60 * (scaledGreen - scaledBlue)) / delta,
+        360
+      );
+    } else if (max === scaledGreen) {
+      this.hueInternal = positiveMod(
+        120 + (60 * (scaledBlue - scaledRed)) / delta,
+        360
+      );
+    } else if (max === scaledBlue) {
+      this.hueInternal = positiveMod(
+        240 + (60 * (scaledRed - scaledGreen)) / delta,
+        360
+      );
+    }
+
+    this.lightnessInternal = 50 * (max + min);
+
+    if (max === min) {
+      this.saturationInternal = 0;
+    } else if (this.lightnessInternal < 50) {
+      this.saturationInternal = (100 * delta) / (max + min);
+    } else {
+      this.saturationInternal = (100 * delta) / (2 - max - min);
+    }
+  }
+
+  // Computes `this`'s red`, `green`, and `blue` channels based on `hue`,
+  // `saturation`, and `value`.
+  //
+  // Algorithm from the CSS3 spec: https://www.w3.org/TR/css3-color/#hsl-color.
+  private hslToRgb(): void {
+    const scaledHue = this.hue / 360;
+    const scaledSaturation = this.saturation / 100;
+    const scaledLightness = this.lightness / 100;
+
+    const m2 =
+      scaledLightness <= 0.5
+        ? scaledLightness * (scaledSaturation + 1)
+        : scaledLightness +
+          scaledSaturation -
+          scaledLightness * scaledSaturation;
+    const m1 = scaledLightness * 2 - m2;
+
+    this.redInternal = fuzzyRound(hueToRgb(m1, m2, scaledHue + 1 / 3) * 255);
+    this.greenInternal = fuzzyRound(hueToRgb(m1, m2, scaledHue) * 255);
+    this.blueInternal = fuzzyRound(hueToRgb(m1, m2, scaledHue - 1 / 3) * 255);
+  }
+}
+
+// A helper for converting HWB colors to RGB.
+function hwbToRgb(
+  hue: number,
+  scaledWhiteness: number,
+  scaledBlackness: number
+) {
+  const factor = 1 - scaledWhiteness - scaledBlackness;
+  const channel = hueToRgb(0, 1, hue) * factor + scaledWhiteness;
+  return fuzzyRound(channel * 255);
+}
+
+// An algorithm from the CSS3 spec: http://www.w3.org/TR/css3-color/#hsl-color.
+function hueToRgb(m1: number, m2: number, hue: number): number {
+  if (hue < 0) hue += 1;
+  if (hue > 1) hue -= 1;
+
+  if (hue < 1 / 6) {
+    return m1 + (m2 - m1) * hue * 6;
+  } else if (hue < 1 / 2) {
+    return m2;
+  } else if (hue < 2 / 3) {
+    return m1 + (m2 - m1) * (2 / 3 - hue) * 6;
+  } else {
+    return m1;
+  }
+}

--- a/lib/src/value/function.ts
+++ b/lib/src/value/function.ts
@@ -1,0 +1,71 @@
+// Copyright 2021 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {hash} from 'immutable';
+
+import {CustomFunction} from '../vendor/sass';
+import {Value} from './index';
+
+/** A first-class SassScript function. */
+export class SassFunction extends Value {
+  /**
+   * If this function is defined in the compiler, this is the unique ID that the
+   * compiler uses to determine which function it refers to.
+   *
+   * This is marked as public so that the protofier can access it, but it's not
+   * part of the package's public API and should not be accessed by user code.
+   * It may be renamed or removed without warning in the future.
+   */
+  readonly id: number | undefined;
+
+  /**
+   * If this function is defined in the host, this is the signature that
+   * describes how to pass arguments to it.
+   *
+   * This is marked as public so that the protofier can access it, but it's not
+   * part of the package's public API and should not be accessed by user code.
+   * It may be renamed or removed without warning in the future.
+   */
+  readonly signature: string | undefined;
+
+  /**
+   * If this function is defined in the host, this is the callback to run when
+   * the function is invoked from a stylesheet.
+   *
+   * This is marked as public so that the protofier can access it, but it's not
+   * part of the package's public API and should not be accessed by user code.
+   * It may be renamed or removed without warning in the future.
+   */
+  readonly callback: CustomFunction<'sync'> | undefined;
+
+  constructor(id: number);
+  constructor(signature: string, callback: CustomFunction<'sync'>);
+  constructor(
+    idOrSignature: number | string,
+    callback?: CustomFunction<'sync'>
+  ) {
+    super();
+
+    if (typeof idOrSignature === 'number') {
+      this.id = idOrSignature;
+    } else {
+      this.signature = idOrSignature;
+      this.callback = callback!;
+    }
+  }
+
+  equals(other: Value): boolean {
+    return this.id === undefined
+      ? other === this
+      : other instanceof SassFunction && other.id === this.id;
+  }
+
+  hashCode(): number {
+    return this.id === undefined ? hash(this.signature) : hash(this.id);
+  }
+
+  toString(): string {
+    return this.signature ? this.signature : `<compiler function ${this.id}>`;
+  }
+}

--- a/lib/src/value/index.ts
+++ b/lib/src/value/index.ts
@@ -1,0 +1,177 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {List, ValueObject} from 'immutable';
+
+import {ListSeparator} from './list';
+import {SassBoolean} from './boolean';
+import {SassColor} from './color';
+import {SassMap} from './map';
+import {SassNumber} from './number';
+import {SassString} from './string';
+import {valueError} from '../utils';
+
+/**
+ * A SassScript value.
+ *
+ * All SassScript values are immutable.
+ *
+ * Concrete values (such as `SassColor`) are implemented as subclasses and get
+ * instantiated as normal JS classes.
+ *
+ * Untyped values can be cast to particular types using `assert*()` functions,
+ * which throw user-friendly error messages if they fail.
+ *
+ * All values, except `false` and `null`, count as `true`.
+ *
+ * All values can be used as lists. Maps count as lists of pairs, while all
+ * other values count as single-value lists. Empty maps are equal to empty
+ * lists.
+ */
+export abstract class Value implements ValueObject {
+  /** Whether `this` counts as `true`. */
+  get isTruthy(): boolean {
+    return true;
+  }
+
+  /** Returns JS null if `this` is `sassNull`. Otherwise, returns `this`. */
+  get realNull(): Value | null {
+    return this;
+  }
+
+  /** `this` as a list. */
+  get asList(): List<Value> {
+    return List([this]);
+  }
+
+  /** The separator for `this` as a list. */
+  get separator(): ListSeparator {
+    return null;
+  }
+
+  /** Whether `this`, as a list, has brackets. */
+  get hasBrackets(): boolean {
+    return false;
+  }
+
+  // Subclasses can override this to change the behavior of
+  // `sassIndexToListIndex`.
+  protected get lengthAsList(): number {
+    return 1;
+  }
+
+  /**
+   * Converts `sassIndex` to a JS index into the array returned by `asList`.
+   *
+   * Sass indices start counting at 1, and may be negative in order to index
+   * from the end of the list.
+   *
+   * `sassIndex` must be...
+   * - a number, and
+   * - an integer, and
+   * - a valid index into `asList`.
+   *
+   * Otherwise, this throws an error.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  sassIndexToListIndex(sassIndex: Value, name?: string): number {
+    const index = sassIndex.assertNumber().assertInt();
+    if (index === 0) {
+      throw Error('List index may not be 0.');
+    }
+    if (Math.abs(index) > this.lengthAsList) {
+      throw valueError(
+        `Invalid index ${sassIndex} for a list with ${this.lengthAsList} elements.`,
+        name
+      );
+    }
+    return index < 0 ? this.lengthAsList + index : index - 1;
+  }
+
+  /** Returns `this.asList.get(index)`. */
+  get(index: number): Value | undefined {
+    return index < 1 && index >= -1 ? this : undefined;
+  }
+
+  /**
+   * Casts `this` to `SassBoolean`; throws if `this` isn't a boolean.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertBoolean(name?: string): SassBoolean {
+    throw valueError(`${this} is not a boolean`, name);
+  }
+
+  /**
+   * Casts `this` to `SassColor`; throws if `this` isn't a color.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertColor(name?: string): SassColor {
+    throw valueError(`${this} is not a color`, name);
+  }
+
+  /**
+   * Casts `this` to `SassFunction`; throws if `this` isn't a function
+   * reference.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertFunction(name?: string): Value {
+    throw valueError(`${this} is not a function reference`, name);
+    // TODO(awjin): Narrow the return type to SassFunction.
+  }
+
+  /**
+   * Casts `this` to `SassMap`; throws if `this` isn't a map.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertMap(name?: string): SassMap {
+    throw valueError(`${this} is not a map`, name);
+  }
+
+  /**
+   * Returns `this` as a `SassMap` if it counts as one (including empty lists),
+   * or `null` if it does not.
+   */
+  tryMap(): SassMap | null {
+    return null;
+  }
+
+  /**
+   * Casts `this` to `SassString`; throws if `this` isn't a string.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertNumber(name?: string): SassNumber {
+    throw valueError(`${this} is not a number`, name);
+  }
+
+  /**
+   * Casts `this` to `SassString`; throws if `this` isn't a string.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertString(name?: string): SassString {
+    throw valueError(`${this} is not a string`, name);
+  }
+
+  /** Whether `this == other` in SassScript. */
+  abstract equals(other: Value): boolean;
+
+  /** This is the same for values that are `==` in SassScript. */
+  abstract hashCode(): number;
+
+  /** A meaningful descriptor for this value. */
+  abstract toString(): string;
+}

--- a/lib/src/value/list.ts
+++ b/lib/src/value/list.ts
@@ -1,0 +1,144 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {hash, isList, List} from 'immutable';
+
+import {Value} from './index';
+import {SassMap} from './map';
+import {asImmutableList, valueError} from '../utils';
+
+/** The types of separator that a SassList can have. */
+export type ListSeparator = ',' | '/' | ' ' | null;
+
+// All empty SassList and SassMaps should have the same hashcode, so this caches
+// the value.
+const emptyListHashCode = hash([]);
+
+/** The options that are passed to the constructor. */
+interface ConstructorOptions {
+  separator?: ListSeparator;
+  brackets?: boolean;
+}
+
+/** A SassScript list. */
+export class SassList extends Value {
+  private readonly contentsInternal: List<Value>;
+  private readonly separatorInternal: ListSeparator;
+  private readonly hasBracketsInternal: boolean;
+
+  /**
+   * Returns a list that contains `contents`, with the given `separator` and
+   * `brackets`.
+   */
+  constructor(
+    contents: Value[] | List<Value>,
+    options?: {
+      separator?: ListSeparator;
+      brackets?: boolean;
+    }
+  );
+  constructor(options?: ConstructorOptions);
+  constructor(
+    contentsOrOptions?: Value[] | List<Value> | ConstructorOptions,
+    options?: ConstructorOptions
+  ) {
+    super();
+
+    if (isList(contentsOrOptions) || Array.isArray(contentsOrOptions)) {
+      this.contentsInternal = asImmutableList(contentsOrOptions);
+    } else {
+      this.contentsInternal = List();
+      options = contentsOrOptions;
+    }
+
+    if (this.contentsInternal.size > 1 && options?.separator === null) {
+      throw Error(
+        'Non-null separator required for SassList with more than one element.'
+      );
+    }
+    this.separatorInternal =
+      options?.separator === undefined ? ',' : options.separator;
+    this.hasBracketsInternal = options?.brackets ?? false;
+  }
+
+  get asList(): List<Value> {
+    return this.contentsInternal;
+  }
+
+  /** Whether `this` has brackets. */
+  get hasBrackets(): boolean {
+    return this.hasBracketsInternal;
+  }
+
+  /** `this`'s list separator. */
+  get separator(): ListSeparator {
+    return this.separatorInternal;
+  }
+
+  protected get lengthAsList(): number {
+    return this.contentsInternal.size;
+  }
+
+  get(index: number): Value | undefined {
+    return this.contentsInternal.get(index);
+  }
+
+  assertList(): SassList {
+    return this;
+  }
+
+  assertMap(name?: string): SassMap {
+    if (this.contentsInternal.isEmpty()) return new SassMap();
+    throw valueError(`${this} is not a map`, name);
+  }
+
+  /**
+   * If `this` is empty, returns an empty OrderedMap.
+   *
+   * Otherwise, returns null.
+   */
+  tryMap(): SassMap | null {
+    return this.contentsInternal.isEmpty() ? new SassMap() : null;
+  }
+
+  equals(other: Value): boolean {
+    if (
+      (other instanceof SassList || other instanceof SassMap) &&
+      this.contentsInternal.isEmpty() &&
+      other.asList.isEmpty()
+    ) {
+      return true;
+    }
+
+    if (
+      !(other instanceof SassList) ||
+      this.hasBrackets !== other.hasBrackets ||
+      this.separator !== other.separator
+    ) {
+      return false;
+    }
+
+    return this.contentsInternal.equals(other.asList);
+  }
+
+  hashCode(): number {
+    return this.contentsInternal.isEmpty()
+      ? emptyListHashCode
+      : this.contentsInternal.hashCode() ^
+          hash(this.hasBrackets) ^
+          hash(this.separator);
+  }
+
+  toString(): string {
+    let string = '';
+    if (this.hasBrackets) string += '[';
+    string += `${this.contentsInternal.join(
+      this.separator === ' ' || this.separator === null
+        ? ' '
+        : `${this.separator} `
+    )}`;
+    if (this.hasBrackets) string += ']';
+    return string;
+  }
+}

--- a/lib/src/value/map.ts
+++ b/lib/src/value/map.ts
@@ -1,0 +1,113 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {List, OrderedMap} from 'immutable';
+
+import {Value} from './index';
+import {ListSeparator, SassList} from './list';
+
+/** A SassScript map */
+export class SassMap extends Value {
+  private readonly contentsInternal: OrderedMap<Value, Value>;
+
+  /** Returns a map that contains `contents`. */
+  constructor(contents?: OrderedMap<Value, Value>) {
+    super();
+    this.contentsInternal = contents ?? OrderedMap();
+  }
+
+  /** The separator for `this`'s contents as a list. */
+  get separator(): ListSeparator {
+    return this.contentsInternal.isEmpty() ? null : ',';
+  }
+
+  /** `this`'s contents. */
+  get contents(): OrderedMap<Value, Value> {
+    return this.contentsInternal;
+  }
+
+  /**
+   * Returns an immutable list of `contents`'s keys and values as two-element
+   * `SassList`s.
+   */
+  get asList(): List<Value> {
+    const list = [];
+    for (const entry of this.contents.entries()) {
+      list.push(new SassList(entry, {separator: ' '}));
+    }
+    return List(list);
+  }
+
+  protected get lengthAsList(): number {
+    return this.contentsInternal.size;
+  }
+
+  get(indexOrKey: number | Value): Value | undefined {
+    if (indexOrKey instanceof Value) {
+      return this.contentsInternal.get(indexOrKey);
+    } else {
+      const entry = this.contentsInternal
+        .entrySeq()
+        .get(Math.floor(indexOrKey));
+      return entry ? new SassList(entry, {separator: ' '}) : undefined;
+    }
+  }
+
+  assertMap(): SassMap {
+    return this;
+  }
+
+  tryMap(): SassMap {
+    return this;
+  }
+
+  equals(other: Value): boolean {
+    if (
+      other instanceof SassList &&
+      this.contents.size === 0 &&
+      other.asList.size === 0
+    ) {
+      return true;
+    }
+
+    if (
+      !(other instanceof SassMap) ||
+      this.contents.size !== other.contents.size
+    ) {
+      return false;
+    }
+
+    for (const [key, value] of this.contents.entries()) {
+      const otherValue = other.contents.get(key);
+      if (otherValue === undefined || !otherValue.equals(value)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  hashCode(): number {
+    return this.contents.isEmpty()
+      ? new SassList().hashCode()
+      : // SassMaps with the same key-value pairs are considered equal
+        // regardless of key-value order, so this hash must be order
+        // independent. Since OrderedMap.hashCode() encodes the key-value order,
+        // we use a manual XOR accumulator instead.
+        this.contents.reduce(
+          (accumulator, value, key) =>
+            accumulator ^ value.hashCode() ^ key.hashCode(),
+          0
+        );
+  }
+
+  toString(): string {
+    let string = '(';
+    string += Array.from(
+      this.contents.entries(),
+      ([key, value]) => `${key}: ${value}`
+    ).join(', ');
+    string += ')';
+    return string;
+  }
+}

--- a/lib/src/value/null.ts
+++ b/lib/src/value/null.ts
@@ -1,0 +1,62 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {hash} from 'immutable';
+
+import {Value} from './index';
+
+const hashCode = hash(null);
+
+// SassScript null. Cannot be constructed; exists only as the exported
+// singleton.
+export class SassNull extends Value {
+  // Whether callers are allowed to construct this class. This is set to
+  // `false` once the two constants are constructed so that the constructor
+  // throws an error for future calls, in accordance with the legacy API.
+  static constructionAllowed = true;
+
+  constructor() {
+    super();
+
+    if (!SassNull.constructionAllowed) {
+      throw (
+        "new sass.types.Null() isn't allowed.\n" +
+        'Use sass.types.Null.NULL instead.'
+      );
+    }
+
+    Object.freeze(this);
+  }
+
+  get isTruthy(): boolean {
+    return false;
+  }
+
+  get realNull(): null {
+    return null;
+  }
+
+  equals(other: Value): boolean {
+    return this === other;
+  }
+
+  hashCode(): number {
+    return hashCode;
+  }
+
+  toString(): string {
+    return 'sassNull';
+  }
+
+  // Legacy API support
+  static NULL: SassNull;
+}
+
+/** The singleton instance of SassScript null. */
+export const sassNull = new SassNull();
+
+// Legacy API support
+SassNull.constructionAllowed = false;
+
+SassNull.NULL = sassNull;

--- a/lib/src/value/number.ts
+++ b/lib/src/value/number.ts
@@ -1,0 +1,717 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {hash, List} from 'immutable';
+
+import {asImmutableList, valueError} from '../utils';
+import {Value} from './index';
+import {
+  fuzzyAsInt,
+  fuzzyEquals,
+  fuzzyHashCode,
+  fuzzyInRange,
+  fuzzyIsInt,
+} from './utils';
+
+// Conversion rates for each unit.
+const conversions: Record<string, Record<string, number>> = {
+  // Length
+  in: {
+    in: 1,
+    cm: 1 / 2.54,
+    pc: 1 / 6,
+    mm: 1 / 25.4,
+    q: 1 / 101.6,
+    pt: 1 / 72,
+    px: 1 / 96,
+  },
+  cm: {
+    in: 2.54,
+    cm: 1,
+    pc: 2.54 / 6,
+    mm: 1 / 10,
+    q: 1 / 40,
+    pt: 2.54 / 72,
+    px: 2.54 / 96,
+  },
+  pc: {
+    in: 6,
+    cm: 6 / 2.54,
+    pc: 1,
+    mm: 6 / 25.4,
+    q: 6 / 101.6,
+    pt: 1 / 12,
+    px: 1 / 16,
+  },
+  mm: {
+    in: 25.4,
+    cm: 10,
+    pc: 25.4 / 6,
+    mm: 1,
+    q: 1 / 4,
+    pt: 25.4 / 72,
+    px: 25.4 / 96,
+  },
+  q: {
+    in: 101.6,
+    cm: 40,
+    pc: 101.6 / 6,
+    mm: 4,
+    q: 1,
+    pt: 101.6 / 72,
+    px: 101.6 / 96,
+  },
+  pt: {
+    in: 72,
+    cm: 72 / 2.54,
+    pc: 12,
+    mm: 72 / 25.4,
+    q: 72 / 101.6,
+    pt: 1,
+    px: 3 / 4,
+  },
+  px: {
+    in: 96,
+    cm: 96 / 2.54,
+    pc: 16,
+    mm: 96 / 25.4,
+    q: 96 / 101.6,
+    pt: 4 / 3,
+    px: 1,
+  },
+
+  // Rotation
+  deg: {
+    deg: 1,
+    grad: 9 / 10,
+    rad: 180 / Math.PI,
+    turn: 360,
+  },
+  grad: {
+    deg: 10 / 9,
+    grad: 1,
+    rad: 200 / Math.PI,
+    turn: 400,
+  },
+  rad: {
+    deg: Math.PI / 180,
+    grad: Math.PI / 200,
+    rad: 1,
+    turn: 2 * Math.PI,
+  },
+  turn: {
+    deg: 1 / 360,
+    grad: 1 / 400,
+    rad: 1 / (2 * Math.PI),
+    turn: 1,
+  },
+
+  // Time
+  s: {
+    s: 1,
+    ms: 1 / 1000,
+  },
+  ms: {
+    s: 1000,
+    ms: 1,
+  },
+
+  // Frequency
+  Hz: {Hz: 1, kHz: 1000},
+  kHz: {Hz: 1 / 1000, kHz: 1},
+
+  // Pixel density
+  dpi: {
+    dpi: 1,
+    dpcm: 2.54,
+    dppx: 96,
+  },
+  dpcm: {
+    dpi: 1 / 2.54,
+    dpcm: 1,
+    dppx: 96 / 2.54,
+  },
+  dppx: {
+    dpi: 1 / 96,
+    dpcm: 2.54 / 96,
+    dppx: 1,
+  },
+};
+
+// A map from each human-readable type of unit to the units that belong to that
+// type.
+const unitsByType: Record<string, string[]> = {
+  length: ['in', 'cm', 'pc', 'mm', 'q', 'pt', 'px'],
+  angle: ['deg', 'grad', 'rad', 'turn'],
+  time: ['s', 'ms'],
+  frequency: ['Hz', 'kHz'],
+  'pixel density': ['dpi', 'dpcm', 'dppx'],
+};
+
+// A map from each unit to its human-readable type.
+const typesByUnit: Record<string, string> = {};
+for (const [type, units] of Object.entries(unitsByType)) {
+  for (const unit of units) {
+    typesByUnit[unit] = type;
+  }
+}
+
+/** A SassScript number. */
+export class SassNumber extends Value {
+  private valueInternal: number;
+  private numeratorUnitsInternal: List<string>;
+  private denominatorUnitsInternal: List<string>;
+
+  constructor(
+    value: number,
+    unitOrOptions?:
+      | string
+      | {
+          numeratorUnits?: string[] | List<string>;
+          denominatorUnits?: string[] | List<string>;
+        }
+  ) {
+    super();
+
+    if (typeof unitOrOptions === 'string') {
+      this.valueInternal = value;
+      this.numeratorUnitsInternal =
+        unitOrOptions === undefined ? List([]) : List([unitOrOptions]);
+      this.denominatorUnitsInternal = List([]);
+      return;
+    }
+
+    let numerators = asImmutableList(unitOrOptions?.numeratorUnits ?? []);
+    const unsimplifiedDenominators = unitOrOptions?.denominatorUnits ?? [];
+
+    const denominators = [];
+    for (const denominator of unsimplifiedDenominators) {
+      let simplifiedAway = false;
+      for (const [i, numerator] of numerators.entries()) {
+        const factor = conversionFactor(denominator, numerator);
+        if (factor === null) continue;
+        value /= factor;
+        numerators = numerators.delete(i);
+        simplifiedAway = true;
+        break;
+      }
+      if (!simplifiedAway) denominators.push(denominator);
+    }
+
+    this.valueInternal = value;
+    this.numeratorUnitsInternal = numerators;
+    this.denominatorUnitsInternal = List(denominators);
+  }
+
+  /** `this`'s value. */
+  get value(): number {
+    return this.valueInternal;
+  }
+
+  /** Whether `value` is an integer. */
+  get isInt(): boolean {
+    return fuzzyIsInt(this.value);
+  }
+
+  /**
+   * If `value` is an integer according to `isInt`, returns `value` rounded to
+   * that integer.
+   *
+   * Otherwise, returns null.
+   */
+  get asInt(): number | null {
+    return fuzzyAsInt(this.value);
+  }
+
+  /** `this`'s numerator units. */
+  get numeratorUnits(): List<string> {
+    return this.numeratorUnitsInternal;
+  }
+
+  /** `this`'s denominator units. */
+  get denominatorUnits(): List<string> {
+    return this.denominatorUnitsInternal;
+  }
+
+  /** Whether `this` has any units. */
+  get hasUnits(): boolean {
+    return !(this.numeratorUnits.isEmpty() && this.denominatorUnits.isEmpty());
+  }
+
+  assertNumber(): SassNumber {
+    return this;
+  }
+
+  /**
+   * If `value` is an integer according to `isInt`, returns it as an integer.
+   *
+   * Otherwise, throws an error.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertInt(name?: string): number {
+    const int = fuzzyAsInt(this.value);
+    if (int === null) {
+      throw valueError(`${this} is not an int`, name);
+    }
+    return int;
+  }
+
+  /**
+   * If `value` is within `min` and `max`, returns `value`, or if it
+   * `fuzzyEquals` `min` or `max`, returns `value` clamped to that value.
+   *
+   * Otherwise, throws an error.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertInRange(min: number, max: number, name?: string): number {
+    const clamped = fuzzyInRange(this.value, min, max);
+    if (clamped === null) {
+      throw valueError(`${this} must be between ${min} and ${max}`, name);
+    }
+    return clamped;
+  }
+
+  /**
+   * If `this` has no units, returns `this`.
+   *
+   * Otherwise, throws an error.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertNoUnits(name?: string): SassNumber {
+    if (this.hasUnits) {
+      throw valueError(`Expected ${this} to have no units`, name);
+    }
+    return this;
+  }
+
+  /**
+   * If `this` has `unit` as its only unit (and as a numerator), returns `this`.
+   *
+   * Otherwise, throws an error.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  assertUnit(unit: string, name?: string): SassNumber {
+    if (!this.hasUnit(unit)) {
+      throw valueError(`Expected ${this} to have no unit ${unit}`, name);
+    }
+    return this;
+  }
+
+  /** Whether `this` has `unit` as its only unit (and as a numerator). */
+  hasUnit(unit: string): boolean {
+    return (
+      this.denominatorUnits.isEmpty() &&
+      this.numeratorUnits.size === 1 &&
+      this.numeratorUnits.get(0) === unit
+    );
+  }
+
+  /** Whether `this` is compatible with `unit`. */
+  compatibleWithUnit(unit: string): boolean {
+    if (!this.denominatorUnits.isEmpty()) return false;
+    if (this.numeratorUnits.size > 1) return false;
+    const numerator = this.numeratorUnits.get(0)!;
+    return typesByUnit[numerator]
+      ? typesByUnit[numerator] === typesByUnit[unit]
+      : numerator === unit;
+  }
+
+  /**
+   * Returns a copy of `this`, converted to the units represented by
+   * `newNumerators` and `newDenominators`.
+   *
+   * Throws an error if `this`'s units are incompatible with `newNumerators` and
+   * `newDenominators`. Also throws an error if `this` is unitless and either
+   * `newNumerators` or `newDenominators` are not empty, or vice-versa.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  convert(
+    newNumerators: string[] | List<string>,
+    newDenominators: string[] | List<string>,
+    name?: string
+  ): SassNumber {
+    return new SassNumber(
+      this.convertValue(newNumerators, newDenominators, name),
+      {numeratorUnits: newNumerators, denominatorUnits: newDenominators}
+    );
+  }
+
+  /**
+   * Returns `value`, converted to the units represented by `newNumerators` and
+   * `newDenominators`.
+   *
+   * Throws an error if `this`'s units are incompatible with `newNumerators` and
+   * `newDenominators`. Also throws an error if `this` is unitless and either
+   * `newNumerators` or `newDenominators` are not empty, or vice-versa.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  convertValue(
+    newNumerators: string[] | List<string>,
+    newDenominators: string[] | List<string>,
+    name?: string
+  ): number {
+    return this.convertOrCoerce({
+      coerceUnitless: false,
+      newNumeratorUnits: asImmutableList(newNumerators),
+      newDenominatorUnits: asImmutableList(newDenominators),
+      name,
+    });
+  }
+
+  /**
+   * Returns a copy of `this`, converted to the same units as `other`.
+   *
+   * Throws an error if `this`'s units are incompatible with `other`'s units, or
+   * if either number is unitless but the other is not.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * and `otherName` is the argument name for `other` (both without the `$`).
+   * They are used for error reporting.
+   */
+  convertToMatch(
+    other: SassNumber,
+    name?: string,
+    otherName?: string
+  ): SassNumber {
+    return new SassNumber(this.convertValueToMatch(other, name, otherName), {
+      numeratorUnits: other.numeratorUnits,
+      denominatorUnits: other.denominatorUnits,
+    });
+  }
+
+  /**
+   * Returns `value`, converted to the same units as `other`.
+   *
+   * Throws an error if `this`'s units are incompatible with `other`'s units, or
+   * if either number is unitless but the other is not.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * and `otherName` is the argument name for `other` (both without the `$`).
+   * They are used for error reporting.
+   */
+  convertValueToMatch(
+    other: SassNumber,
+    name?: string,
+    otherName?: string
+  ): number {
+    return this.convertOrCoerce({
+      coerceUnitless: false,
+      other,
+      name,
+      otherName,
+    });
+  }
+
+  /**
+   * Returns a copy of `this`, converted to the units represented by
+   * `newNumerators` and `newDenominators`.
+   *
+   * Does *not* throw an error if this number is unitless and either
+   * `newNumerators` or `newDenominators` are not empty, or vice-versa. Instead,
+   * it treats all unitless numbers as convertible to and from all units
+   * without changing the value.
+   *
+   * Throws an error if `this`'s units are incompatible with `newNumerators` and
+   * `newDenominators`.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  coerce(
+    newNumerators: string[] | List<string>,
+    newDenominators: string[] | List<string>,
+    name?: string
+  ): SassNumber {
+    return new SassNumber(
+      this.coerceValue(newNumerators, newDenominators, name),
+      {numeratorUnits: newNumerators, denominatorUnits: newDenominators}
+    );
+  }
+
+  /**
+   * Returns `value`, converted to the units represented by `newNumerators` and
+   * `newDenominators`.
+   *
+   * Does *not* throw an error if this number is unitless and either
+   * `newNumerators` or `newDenominators` are not empty, or vice-versa. Instead,
+   * it treats all unitless numbers as convertible to and from all units
+   * without changing the value.
+   *
+   * Throws an error if `this`'s units are incompatible with `newNumerators` and
+   * `newDenominators`.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  coerceValue(
+    newNumerators: string[] | List<string>,
+    newDenominators: string[] | List<string>,
+    name?: string
+  ): number {
+    return this.convertOrCoerce({
+      coerceUnitless: true,
+      newNumeratorUnits: asImmutableList(newNumerators),
+      newDenominatorUnits: asImmutableList(newDenominators),
+      name,
+    });
+  }
+
+  /**
+   * Returns a copy of `this`, converted to the same units as `other`.
+   *
+   * Does *not* throw an error if `this` is unitless and `other` is not, or
+   * vice-versa. Instead, it treats all unitless numbers as convertible to and
+   * from all units without changing the value.
+   *
+   * Throws an error if `this`'s units are incompatible with `other`'s units.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * and `otherName` is the argument name for `other` (both without the `$`).
+   * They are used for error reporting.
+   */
+  coerceToMatch(
+    other: SassNumber,
+    name?: string,
+    otherName?: string
+  ): SassNumber {
+    return new SassNumber(this.coerceValueToMatch(other, name, otherName), {
+      numeratorUnits: other.numeratorUnits,
+      denominatorUnits: other.denominatorUnits,
+    });
+  }
+
+  /**
+   * Returns `value`, converted to the same units as `other`.
+   *
+   * Does *not* throw an error if `this` is unitless and `other` is not, or
+   * vice-versa. Instead, it treats all unitless numbers as convertible to and
+   * from all units without changing the value.
+   *
+   * Throws an error if `this`'s units are incompatible with `other`'s units.
+   *
+   * If `this` came from a function argument, `name` is the argument name
+   * and `otherName` is the argument name for `other` (both without the `$`).
+   * They are used for error reporting.
+   */
+  coerceValueToMatch(
+    other: SassNumber,
+    name?: string,
+    otherName?: string
+  ): number {
+    return this.convertOrCoerce({
+      coerceUnitless: true,
+      other,
+      name,
+      otherName,
+    });
+  }
+
+  equals(other: Value): boolean {
+    if (!(other instanceof SassNumber)) return false;
+    try {
+      return fuzzyEquals(this.value, other.convertValueToMatch(this));
+    } catch {
+      return false;
+    }
+  }
+
+  hashCode(): number {
+    const canonicalNumerators = canonicalizeUnits(this.numeratorUnits);
+    const canonicalDenominators = canonicalizeUnits(this.denominatorUnits);
+    const canonicalValue = this.convertValue(
+      canonicalNumerators,
+      canonicalDenominators
+    );
+    return (
+      fuzzyHashCode(canonicalValue) ^
+      hash(canonicalNumerators) ^
+      hash(canonicalDenominators)
+    );
+  }
+
+  toString(): string {
+    return `${this.value}${unitString(
+      this.numeratorUnits,
+      this.denominatorUnits
+    )}`;
+  }
+
+  // Returns the value of converting `number` to new units.
+  //
+  // The units may be specified as lists of units (`newNumeratorUnits` and
+  // `newDenominatorUnits`), or by providng a SassNumber `other` that contains the
+  // desired units.
+  //
+  // Throws an error if `number` is not compatible with the new units. Coercing a
+  // unitful number to unitless (or vice-versa) throws an error unless
+  // specifically enabled with `coerceUnitless`.
+  private convertOrCoerce(
+    params: {
+      name?: string;
+      coerceUnitless: boolean;
+    } & (
+      | {
+          newNumeratorUnits: List<string>;
+          newDenominatorUnits: List<string>;
+        }
+      | {
+          other: SassNumber;
+          otherName?: string;
+        }
+    )
+  ): number {
+    const newNumerators =
+      'other' in params
+        ? params.other.numeratorUnits
+        : params.newNumeratorUnits;
+    const newDenominators =
+      'other' in params
+        ? params.other.denominatorUnits
+        : params.newDenominatorUnits;
+
+    const compatibilityError = (): Error => {
+      if ('other' in params) {
+        let message = `${this} and`;
+        if (params.otherName) {
+          message += ` $${params.otherName}:`;
+        }
+        message += ` ${params.other} have incompatible units`;
+        if (!this.hasUnits || !otherHasUnits) {
+          message += " (one has units and the other doesn't)";
+        }
+        return valueError(message, params.name);
+      }
+
+      if (!otherHasUnits) {
+        return valueError(`Expected ${this} to have no units.`, params.name);
+      }
+
+      // For single numerators, throw a detailed error with info about which unit
+      // types would have been acceptable.
+      if (newNumerators.size === 1 && newDenominators.isEmpty()) {
+        const type = typesByUnit[newNumerators.get(0)!];
+        if (type) {
+          return valueError(
+            `Expected ${this} to have a single ${type} unit (${unitsByType[
+              type
+            ].join(', ')}).`,
+            params.name
+          );
+        }
+      }
+
+      const unitSize = newNumerators.size + newDenominators.size;
+      return valueError(
+        `Expected $this to have ${
+          unitSize === 0
+            ? 'no units'
+            : `unit${unitSize > 1 ? 's' : ''} ${unitString(
+                newNumerators,
+                newDenominators
+              )}`
+        }.`,
+        params.name
+      );
+    };
+
+    const otherHasUnits =
+      !newNumerators.isEmpty() || !newDenominators.isEmpty();
+    if (
+      (this.hasUnits && !otherHasUnits) ||
+      (!this.hasUnits && otherHasUnits)
+    ) {
+      if (params.coerceUnitless) return this.value;
+      throw compatibilityError();
+    }
+
+    if (
+      this.numeratorUnits.equals(newNumerators) &&
+      this.denominatorUnits.equals(newDenominators)
+    ) {
+      return this.value;
+    }
+
+    let value = this.value;
+    let oldNumerators = this.numeratorUnits;
+    for (const newNumerator of newNumerators) {
+      const idx = oldNumerators.findIndex(oldNumerator => {
+        const factor = conversionFactor(oldNumerator, newNumerator);
+        if (factor === null) return false;
+        value *= factor;
+        return true;
+      });
+      if (idx < 0) throw compatibilityError();
+      oldNumerators = oldNumerators.delete(idx);
+    }
+    let oldDenominators = this.denominatorUnits;
+    for (const newDenominator of newDenominators) {
+      const idx = oldDenominators.findIndex(oldDenominator => {
+        const factor = conversionFactor(oldDenominator, newDenominator);
+        if (factor === null) return false;
+        value /= factor;
+        return true;
+      });
+      if (idx < 0) throw compatibilityError();
+      oldDenominators = oldDenominators.delete(idx);
+    }
+    if (!oldNumerators.isEmpty() || !oldDenominators.isEmpty()) {
+      throw compatibilityError();
+    }
+    return value;
+  }
+}
+
+// Returns the conversion factor needed to convert from `fromUnit` to `toUnit`.
+// Returns null if no such factor exists.
+function conversionFactor(fromUnit: string, toUnit: string): number | null {
+  if (fromUnit === toUnit) return 1;
+  const factors = conversions[toUnit];
+  if (!factors) return null;
+  return factors[fromUnit] ?? null;
+}
+
+// Returns a human-readable string representation of `numerators` and
+// `denominators`.
+function unitString(
+  numerators: List<string>,
+  denominators: List<string>
+): string {
+  if (numerators.isEmpty() && denominators.isEmpty()) {
+    return '';
+  }
+
+  if (denominators.isEmpty()) {
+    return numerators.join('*');
+  }
+
+  if (numerators.isEmpty()) {
+    return denominators.size === 1
+      ? `${denominators.get(0)}^-1`
+      : `(${denominators.join('*')})^-1`;
+  }
+
+  return `${numerators.join('*')}/${denominators.join('*')}`;
+}
+
+// Converts the `units` list into an equivalent canonical list.
+function canonicalizeUnits(units: List<string>): List<string> {
+  return units
+    .map(unit => {
+      const type = typesByUnit[unit];
+      return type ? unitsByType[type][0] : unit;
+    })
+    .sort();
+}

--- a/lib/src/value/string.ts
+++ b/lib/src/value/string.ts
@@ -1,0 +1,137 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {hash} from 'immutable';
+
+import {Value} from './index';
+import {valueError} from '../utils';
+
+/** A SassScript string. */
+export class SassString extends Value {
+  private readonly textInternal: string;
+  private readonly hasQuotesInternal: boolean;
+
+  /** Creates a string with `text`, optionally with quotes. */
+  constructor(text: string, options?: {quotes?: boolean});
+  constructor(options?: {quotes?: boolean});
+  constructor(
+    textOrOptions?: string | {quotes?: boolean},
+    options?: {quotes?: boolean}
+  ) {
+    super();
+
+    if (typeof textOrOptions === 'string') {
+      this.textInternal = textOrOptions;
+      this.hasQuotesInternal = options?.quotes ?? true;
+    } else {
+      this.textInternal = '';
+      this.hasQuotesInternal = textOrOptions?.quotes ?? true;
+    }
+  }
+
+  /** Creates an empty string, optionally with quotes. */
+  static empty(options?: {/** @default true */ quotes?: boolean}): SassString {
+    return options === undefined || options?.quotes
+      ? emptyQuoted
+      : emptyUnquoted;
+  }
+
+  /** `this`'s text. */
+  get text(): string {
+    return this.textInternal;
+  }
+
+  /** Whether `this` has quotes. */
+  get hasQuotes(): boolean {
+    return this.hasQuotesInternal;
+  }
+
+  assertString(): SassString {
+    return this;
+  }
+
+  /**
+   * Sass's notion of `this`'s length.
+   *
+   * Sass treats strings as a series of Unicode code points while JS treats them
+   * as a series of UTF-16 code units. For example, the character U+1F60A,
+   * Smiling Face With Smiling Eyes, is a single Unicode code point but is
+   * represented in UTF-16 as two code units (`0xD83D` and `0xDE0A`). So in
+   * JS, `"n😊b".length` returns `4`, whereas in Sass `string.length("n😊b")`
+   * returns `3`.
+   */
+  get sassLength(): number {
+    let length = 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const codepoint of this.text) {
+      length++;
+    }
+    return length;
+  }
+
+  /**
+   * Converts `sassIndex` to a JS index into `text`.
+   *
+   * Sass indices are one-based, while JS indices are zero-based. Sass
+   * indices may also be negative in order to index from the end of the string.
+   *
+   * In addition, Sass indices refer to Unicode code points while JS string
+   * indices refer to UTF-16 code units. For example, the character U+1F60A,
+   * Smiling Face With Smiling Eyes, is a single Unicode code point but is
+   * represented in UTF-16 as two code units (`0xD83D` and `0xDE0A`). So in
+   * JS, `"n😊b".charAt(1)` returns `0xD83D`, whereas in Sass
+   * `string.slice("n😊b", 1, 1)` returns `"😊"`.
+   *
+   * This function converts Sass's code point indices to JS's code unit
+   * indices. This means it's O(n) in the length of `text`.
+   *
+   * Throws an error `sassIndex` isn't a number, if that number isn't an
+   * integer, or if that integer isn't a valid index for this string.
+   *
+   * If `sassIndex` came from a function argument, `name` is the argument name
+   * (without the `$`) and is used for error reporting.
+   */
+  sassIndexToStringIndex(sassIndex: Value, name?: string): number {
+    let sassIdx = sassIndex.assertNumber().assertInt();
+    if (sassIdx === 0) {
+      throw valueError('String index may not be 0', name);
+    }
+
+    const sassLength = this.sassLength;
+    if (Math.abs(sassIdx) > sassLength) {
+      throw valueError(
+        `Invalid index ${sassIdx} for a string with ${sassLength} characters`,
+        name
+      );
+    }
+    if (sassIdx < 0) sassIdx += sassLength + 1;
+
+    let pointer = 1;
+    let idx = 0;
+    for (const codePoint of this.text) {
+      if (pointer === sassIdx) break;
+      idx += codePoint.length;
+      pointer++;
+    }
+    return idx;
+  }
+
+  equals(other: Value): boolean {
+    return other instanceof SassString && this.text === other.text;
+  }
+
+  hashCode(): number {
+    return hash(this.text);
+  }
+
+  toString(): string {
+    return this.hasQuotes ? `"${this.text}"` : this.text;
+  }
+}
+
+// A quoted empty string returned by `SassString.empty()`.
+const emptyQuoted = new SassString('', {quotes: true});
+
+// An unquoted empty string returned by `SassString.empty()`.
+const emptyUnquoted = new SassString('', {quotes: false});

--- a/lib/src/value/utils.ts
+++ b/lib/src/value/utils.ts
@@ -1,0 +1,122 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {hash} from 'immutable';
+
+import {valueError} from '../utils';
+
+/** The precision of Sass numbers. */
+export const precision = 10;
+
+// The max distance two Sass numbers can be from each another before they're
+// considered different.
+//
+// Uses ** instead of Math.pow() for constant folding.
+const epsilon = 10 ** (-precision - 1);
+
+/** Whether `num1` and `num2` are equal within `epsilon`. */
+export function fuzzyEquals(num1: number, num2: number): boolean {
+  return Math.abs(num1 - num2) < epsilon;
+}
+
+/**
+ * Returns a hash code for `num`.
+ *
+ * Two numbers that `fuzzyEquals` each other must have the same hash code.
+ */
+export function fuzzyHashCode(num: number): number {
+  return !isFinite(num) || isNaN(num)
+    ? hash(num)
+    : hash(Math.round(num / epsilon));
+}
+
+/** Whether `num1` < `num2`, within `epsilon`. */
+export function fuzzyLessThan(num1: number, num2: number): boolean {
+  return num1 < num2 && !fuzzyEquals(num1, num2);
+}
+
+/** Whether `num1` <= `num2`, within `epsilon`. */
+export function fuzzyLessThanOrEquals(num1: number, num2: number): boolean {
+  return num1 < num2 || fuzzyEquals(num1, num2);
+}
+
+/** Whether `num1` > `num2`, within `epsilon`. */
+export function fuzzyGreaterThan(num1: number, num2: number): boolean {
+  return num1 > num2 && !fuzzyEquals(num1, num2);
+}
+
+/** Whether `num1` >= `num2`, within `epsilon`. */
+export function fuzzyGreaterThanOrEquals(num1: number, num2: number): boolean {
+  return num1 > num2 || fuzzyEquals(num1, num2);
+}
+
+/** Whether `num` `fuzzyEquals` an integer. */
+export function fuzzyIsInt(num: number): boolean {
+  return !isFinite(num) || isNaN(num)
+    ? false
+    : // Check against 0.5 rather than 0.0 so that we catch numbers that are
+      // both very slightly above an integer, and very slightly below.
+      fuzzyEquals(Math.abs(num - 0.5) % 1, 0.5);
+}
+
+/**
+ * If `num` `fuzzyIsInt`, returns it as an integer. Otherwise, returns `null`.
+ */
+export function fuzzyAsInt(num: number): number | null {
+  return fuzzyIsInt(num) ? Math.round(num) : null;
+}
+
+/**
+ * Rounds `num` to the nearest integer.
+ *
+ * If `num` `fuzzyEquals` `x.5`, rounds away from zero.
+ */
+export function fuzzyRound(num: number): number {
+  if (num > 0) {
+    return fuzzyLessThan(num % 1, 0.5) ? Math.floor(num) : Math.ceil(num);
+  } else {
+    return fuzzyGreaterThan(num % 1, -0.5) ? Math.ceil(num) : Math.floor(num);
+  }
+}
+
+/**
+ * Returns `num` if it's within `min` and `max`, or `null` if it's not.
+ *
+ * If `num` `fuzzyEquals` `min` or `max`, it gets clamped to that value.
+ */
+export function fuzzyInRange(
+  num: number,
+  min: number,
+  max: number
+): number | null {
+  if (fuzzyEquals(num, min)) return min;
+  if (fuzzyEquals(num, max)) return max;
+  if (num > min && num < max) return num;
+  return null;
+}
+
+/**
+ * Returns `num` if it's within `min` and `max`. Otherwise, throws an error.
+ *
+ * If `num` `fuzzyEquals` `min` or `max`, it gets clamped to that value.
+ *
+ * If `name` is provided, it is used as the parameter name for error reporting.
+ */
+export function fuzzyAssertInRange(
+  num: number,
+  min: number,
+  max: number,
+  name?: string
+): number {
+  if (fuzzyEquals(num, min)) return min;
+  if (fuzzyEquals(num, max)) return max;
+  if (num > min && num < max) return num;
+  throw valueError(`${num} must be between ${min} and ${max}`, name);
+}
+
+/** Returns `dividend % modulus`, but always in the range `[0, modulus)`. */
+export function positiveMod(dividend: number, modulus: number) {
+  const result = dividend % modulus;
+  return result < 0 ? result + modulus : result;
+}

--- a/npm/darwin-arm64/README.md
+++ b/npm/darwin-arm64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-darwin-arm64`
+
+This is the **darwin-arm64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sass-embedded-darwin-arm64",
+  "version": "1.56.2",
+  "description": "The darwin-arm64 binary for sass-embedded",
+  "repository": "sass/embedded-host-node",
+  "author": "Google Inc.",
+  "license": "MIT",
+  "files": [
+    "dart-sass-embedded/**/*"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/npm/darwin-x64/README.md
+++ b/npm/darwin-x64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-darwin-x64`
+
+This is the **darwin-x64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sass-embedded-darwin-x64",
+  "version": "1.56.2",
+  "description": "The darwin-x64 binary for sass-embedded",
+  "repository": "sass/embedded-host-node",
+  "author": "Google Inc.",
+  "license": "MIT",
+  "files": [
+    "dart-sass-embedded/**/*"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/npm/linux-arm/README.md
+++ b/npm/linux-arm/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-linux-arm`
+
+This is the **linux-arm** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-arm/package.json
+++ b/npm/linux-arm/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sass-embedded-linux-arm",
+  "version": "1.56.2",
+  "description": "The linux-arm binary for sass-embedded",
+  "repository": "sass/embedded-host-node",
+  "author": "Google Inc.",
+  "license": "MIT",
+  "files": [
+    "dart-sass-embedded/**/*"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm"
+  ]
+}

--- a/npm/linux-arm64/README.md
+++ b/npm/linux-arm64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-linux-arm64`
+
+This is the **linux-arm64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sass-embedded-linux-arm64",
+  "version": "1.56.2",
+  "description": "The linux-arm64 binary for sass-embedded",
+  "repository": "sass/embedded-host-node",
+  "author": "Google Inc.",
+  "license": "MIT",
+  "files": [
+    "dart-sass-embedded/**/*"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ]
+}

--- a/npm/linux-ia32/README.md
+++ b/npm/linux-ia32/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-linux-ia32`
+
+This is the **linux-ia32** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-ia32/package.json
+++ b/npm/linux-ia32/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sass-embedded-linux-ia32",
+  "version": "1.56.2",
+  "description": "The linux-ia32 binary for sass-embedded",
+  "repository": "sass/embedded-host-node",
+  "author": "Google Inc.",
+  "license": "MIT",
+  "files": [
+    "dart-sass-embedded/**/*"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "ia32"
+  ]
+}

--- a/npm/linux-x64/README.md
+++ b/npm/linux-x64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-linux-x64`
+
+This is the **linux-x64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sass-embedded-linux-x64",
+  "version": "1.56.2",
+  "description": "The linux-x64 binary for sass-embedded",
+  "repository": "sass/embedded-host-node",
+  "author": "Google Inc.",
+  "license": "MIT",
+  "files": [
+    "dart-sass-embedded/**/*"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/npm/win32-ia32/README.md
+++ b/npm/win32-ia32/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-win32-ia32`
+
+This is the **win32-ia32** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/win32-ia32/package.json
+++ b/npm/win32-ia32/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sass-embedded-win32-ia32",
+  "version": "1.56.2",
+  "description": "The win32-ia32 binary for sass-embedded",
+  "repository": "sass/embedded-host-node",
+  "author": "Google Inc.",
+  "license": "MIT",
+  "files": [
+    "dart-sass-embedded/**/*"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "ia32"
+  ]
+}

--- a/npm/win32-x64/README.md
+++ b/npm/win32-x64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-win32-x64`
+
+This is the **win32-x64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sass-embedded-win32-x64",
+  "version": "1.56.2",
+  "description": "The win32-x64 binary for sass-embedded",
+  "repository": "sass/embedded-host-node",
+  "author": "Google Inc.",
+  "license": "MIT",
+  "files": [
+    "dart-sass-embedded/**/*"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "sass-embedded",
+  "version": "1.56.2",
+  "protocol-version": "1.1.0",
+  "compiler-version": "1.56.3-dev",
+  "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
+  "repository": "sass/embedded-host-node",
+  "author": "Google Inc.",
+  "license": "MIT",
+  "main": "dist/lib/index.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "scripts": {
+    "init": "ts-node ./tool/init.ts",
+    "check": "npm-run-all check:gts check:tsc",
+    "check:gts": "gts check",
+    "check:tsc": "tsc --noEmit",
+    "clean": "gts clean",
+    "compile": "tsc",
+    "fix": "gts fix",
+    "prepublishOnly": "npm run clean && ts-node ./tool/prepare-release.ts",
+    "test": "jest"
+  },
+  "optionalDependencies": {
+    "sass-embedded-darwin-arm64": "1.56.2",
+    "sass-embedded-darwin-x64": "1.56.2",
+    "sass-embedded-linux-arm": "1.56.2",
+    "sass-embedded-linux-arm64": "1.56.2",
+    "sass-embedded-linux-ia32": "1.56.2",
+    "sass-embedded-linux-x64": "1.56.2",
+    "sass-embedded-win32-ia32": "1.56.2",
+    "sass-embedded-win32-x64": "1.56.2"
+  },
+  "dependencies": {
+    "buffer-builder": "^0.2.0",
+    "google-protobuf": "^3.11.4",
+    "immutable": "^4.0.0",
+    "rxjs": "^7.4.0",
+    "supports-color": "^8.1.1"
+  },
+  "devDependencies": {
+    "@types/buffer-builder": "^0.2.0",
+    "@types/google-protobuf": "^3.7.2",
+    "@types/jest": "^27.0.2",
+    "@types/node": "^16.10.3",
+    "@types/node-fetch": "^2.6.0",
+    "@types/shelljs": "^0.8.8",
+    "@types/supports-color": "^8.1.1",
+    "@types/tar": "^6.1.0",
+    "@types/yargs": "^17.0.4",
+    "del": "^6.0.0",
+    "extract-zip": "^2.0.1",
+    "gts": "^4.0.0",
+    "jest": "^27.2.5",
+    "minipass": "3.2.1",
+    "node-fetch": "^2.6.0",
+    "npm-run-all": "^4.1.5",
+    "protoc": "1.0.4",
+    "shelljs": "^0.8.4",
+    "source-map-js": "^0.6.1",
+    "tar": "^6.0.5",
+    "ts-jest": "^27.0.5",
+    "ts-node": "^10.2.1",
+    "ts-protoc-gen": "^0.15.0",
+    "typescript": "^4.4.3",
+    "yaml": "^1.10.2",
+    "yargs": "^17.2.1"
+  }
+}

--- a/test/dependencies.test.ts
+++ b/test/dependencies.test.ts
@@ -1,0 +1,42 @@
+// Copyright 2022 Google LLC. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+import * as p from 'path';
+
+import * as pkg from '../package.json';
+
+// These tests assert that our declared dependencies on the embedded protocol
+// and compiler are either -dev versions (which download the latest main
+// branches of each repo and block release) or the same versions as the versions
+// we're testing against.
+
+it('declares a compatible dependency on the embedded protocol', () => {
+  if (pkg['protocol-version'].endsWith('-dev')) return;
+
+  expect(
+    fs
+      .readFileSync(
+        p.join(__dirname, '../lib/src/vendor/embedded-protocol/VERSION'),
+        'utf-8'
+      )
+      .trim()
+  ).toBe(pkg['protocol-version']);
+});
+
+it('declares a compatible dependency on the embedded compiler', () => {
+  if (pkg['compiler-version'].endsWith('-dev')) return;
+
+  const version = JSON.parse(
+    child_process.execSync(
+      p.join(
+        __dirname,
+        '../lib/src/vendor/dart-sass-embedded/dart-sass-embedded'
+      ) + ' --version',
+      {encoding: 'utf-8'}
+    )
+  );
+  expect(version.compilerVersion).toBe(pkg['compiler-version']);
+});

--- a/test/sandbox.ts
+++ b/test/sandbox.ts
@@ -1,0 +1,44 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as fs from 'fs';
+import * as p from 'path';
+import * as del from 'del';
+
+import {PromiseOr} from '../lib/src/utils';
+
+/**
+ * Runs `test` within a sandbox directory. This directory is made available via
+ * the `dir` function, which acts like `p.join()` but includes the sandbox
+ * directory at the beginning.
+ *
+ * Handles all buildup and teardown. Returns a promise that resolves when `test`
+ * finishes running.
+ */
+export async function run(
+  test: (dir: (...paths: string[]) => string) => PromiseOr<void>,
+  options?: {
+    // Directories to put in the SASS_PATH env variable before running test.
+    sassPathDirs?: string[];
+  }
+): Promise<void> {
+  const testDir = p.join(
+    p.dirname(__filename),
+    'sandbox',
+    `${Math.random()}`.slice(2)
+  );
+  fs.mkdirSync(testDir, {recursive: true});
+  if (options?.sassPathDirs) {
+    process.env.SASS_PATH = options.sassPathDirs.join(
+      process.platform === 'win32' ? ';' : ':'
+    );
+  }
+  try {
+    await test((...paths) => p.join(testDir, ...paths));
+  } finally {
+    if (options?.sassPathDirs) process.env.SASS_PATH = undefined;
+    // TODO(awjin): Change this to rmSync once we drop support for Node 12.
+    del.sync(testDir, {force: true});
+  }
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,59 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {Observable} from 'rxjs';
+import {Value} from '../lib/src/value';
+
+/**
+ * Subscribes to `observable` and asserts that it errors with the expected
+ * `errorMessage`. Calls `done()` to complete the spec.
+ */
+export function expectObservableToError<T>(
+  observable: Observable<T>,
+  errorMessage: string,
+  done: () => void
+): void {
+  observable.subscribe({
+    next: () => fail('expected error'),
+    error: error => {
+      expect(error.message).toBe(errorMessage);
+      done();
+    },
+    complete: () => fail('expected error'),
+  });
+}
+
+/**
+ * Asserts that the `actual` path is equal to the `expected` one, accounting for
+ * OS differences.
+ */
+export function expectEqualPaths(actual: string, expected: string): void {
+  if (process.platform === 'win32') {
+    expect(actual.toLowerCase()).toBe(expected.toLowerCase());
+  } else {
+    expect(actual).toBe(expected);
+  }
+}
+
+/**
+ * Asserts that `string1` is equal to `string2`, ignoring all whitespace in
+ * either string.
+ */
+export function expectEqualIgnoringWhitespace(
+  string1: string,
+  string2: string
+): void {
+  function strip(str: string) {
+    return str.replace(/\s+/g, '');
+  }
+  expect(strip(string1)).toBe(strip(string2));
+}
+
+/**
+ * Asserts that `val1` and `val2` are equal and have the same hashcode.
+ */
+export function expectEqualWithHashCode(val1: Value, val2: Value): void {
+  expect(val1.equals(val2)).toBe(true);
+  expect(val1.hashCode()).toBe(val2.hashCode());
+}

--- a/tool/get-embedded-compiler.ts
+++ b/tool/get-embedded-compiler.ts
@@ -1,0 +1,76 @@
+// Copyright 2022 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {promises as fs} from 'fs';
+import * as p from 'path';
+import * as yaml from 'yaml';
+import * as shell from 'shelljs';
+
+import * as utils from './utils';
+
+/**
+ * Downlaods and builds the Embedded Dart Sass compiler.
+ *
+ * Can check out and build the source from a Git `ref` or build from the source
+ * at `path`. By default, checks out the latest revision from GitHub.
+ */
+export async function getEmbeddedCompiler(
+  outPath: string,
+  options?: {ref: string} | {path: string}
+): Promise<void> {
+  const repo = 'dart-sass-embedded';
+
+  let source: string;
+  if (!options || 'ref' in options) {
+    utils.fetchRepo({
+      repo,
+      outPath: utils.BUILD_PATH,
+      ref: options?.ref ?? 'main',
+    });
+    source = p.join(utils.BUILD_PATH, repo);
+    await maybeOverrideSassDependency(source);
+  } else {
+    source = options.path;
+  }
+
+  buildDartSassEmbedded(source);
+  await utils.link(p.join(source, 'build'), p.join(outPath, repo));
+}
+
+/**
+ * Overrides Embedded Dart Sass compiler's dependency on Dart Sass to use the
+ * latest version of Dart Sass from the `main` branch.
+ *
+ * This allows us to avoid needing to commit a dependency override to the
+ * embedded compiler when it doesn't actually require any local changes.
+ */
+async function maybeOverrideSassDependency(repo: string): Promise<void> {
+  const pubspecPath = p.join(repo, 'pubspec.yaml');
+  const pubspec = yaml.parse(
+    await fs.readFile(pubspecPath, {encoding: 'utf-8'})
+  );
+
+  console.log(`Overriding ${repo} to load Dart Sass from HEAD.`);
+
+  pubspec['dependency_overrides'] = {
+    ...pubspec['dependency_overrides'],
+    sass: {git: 'https://github.com/sass/dart-sass.git'},
+  };
+  await fs.writeFile(pubspecPath, yaml.stringify(pubspec), {encoding: 'utf-8'});
+}
+
+// Builds the Embedded Dart Sass executable from the source at `repoPath`.
+function buildDartSassEmbedded(repoPath: string): void {
+  console.log('Downloading dart-sass-embedded dependencies.');
+  shell.exec('dart pub upgrade', {
+    cwd: repoPath,
+    silent: true,
+  });
+
+  console.log('Building dart-sass-embedded executable.');
+  shell.exec('dart run grinder protobuf pkg-standalone-dev', {
+    cwd: repoPath,
+    silent: true,
+  });
+}

--- a/tool/get-embedded-protocol.ts
+++ b/tool/get-embedded-protocol.ts
@@ -1,0 +1,72 @@
+// Copyright 2022 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {mkdirSync} from 'fs';
+import * as p from 'path';
+import * as shell from 'shelljs';
+
+import * as pkg from '../package.json';
+import * as utils from './utils';
+
+/**
+ * Downloads and builds the Embedded Sass protocol definition.
+ *
+ * Can check out and build the source from a Git `ref` or build from the source
+ * at `path`. By default, checks out the tagged version specified in
+ * package.json's `protocol-version` field. If this version ends in `-dev`,
+ * checks out the latest revision from GitHub instead.
+ */
+export async function getEmbeddedProtocol(
+  outPath: string,
+  options?: {ref: string} | {path: string}
+): Promise<void> {
+  const repo = 'embedded-protocol';
+
+  let source: string;
+  if (!options || 'ref' in options) {
+    let ref = options?.ref;
+    if (ref === undefined) {
+      const version = pkg['protocol-version'] as string;
+      ref = version.endsWith('-dev') ? 'main' : version;
+    }
+
+    utils.fetchRepo({repo, outPath: utils.BUILD_PATH, ref});
+    source = p.join(utils.BUILD_PATH, repo);
+  } else {
+    source = options.path;
+  }
+
+  buildEmbeddedProtocol(source);
+  await utils.link('build/embedded-protocol', p.join(outPath, repo));
+}
+
+// Builds the embedded proto at `repoPath` into a pbjs with TS declaration file.
+function buildEmbeddedProtocol(repoPath: string): void {
+  const proto = p.join(repoPath, 'embedded_sass.proto');
+  const protocPath =
+    process.platform === 'win32'
+      ? '%CD%/node_modules/protoc/protoc/bin/protoc.exe'
+      : 'node_modules/protoc/protoc/bin/protoc';
+  const version = shell
+    .exec(`${protocPath} --version`, {silent: true})
+    .stdout.trim();
+  console.log(
+    `Building pbjs and TS declaration file from ${proto} with ${version}.`
+  );
+
+  const pluginPath =
+    process.platform === 'win32'
+      ? '%CD%/node_modules/.bin/protoc-gen-ts.cmd'
+      : 'node_modules/.bin/protoc-gen-ts';
+  mkdirSync('build/embedded-protocol', {recursive: true});
+  shell.exec(
+    `${protocPath} \
+      --plugin="protoc-gen-ts=${pluginPath}" \
+      --js_out="import_style=commonjs,binary:build/embedded-protocol" \
+      --ts_out="build/embedded-protocol" \
+      --proto_path="${repoPath}" \
+      ${proto}`,
+    {silent: true}
+  );
+}

--- a/tool/get-js-api.ts
+++ b/tool/get-js-api.ts
@@ -1,0 +1,34 @@
+// Copyright 2022 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import * as p from 'path';
+
+import * as utils from './utils';
+
+/**
+ * Checks out JS API type definitions from the Sass language repo.
+ *
+ * Can check out a Git `ref` or link to the source at `path`. By default, checks
+ * out the latest revision from GitHub.
+ */
+export async function getJSApi(
+  outPath: string,
+  options?: {ref: string} | {path: string}
+): Promise<void> {
+  const repo = 'sass';
+
+  let source: string;
+  if (!options || 'ref' in options) {
+    utils.fetchRepo({
+      repo,
+      outPath: utils.BUILD_PATH,
+      ref: options?.ref ?? 'main',
+    });
+    source = p.join(utils.BUILD_PATH, repo);
+  } else {
+    source = options.path;
+  }
+
+  await utils.link(p.join(source, 'js-api-doc'), p.join(outPath, repo));
+}

--- a/tool/init.ts
+++ b/tool/init.ts
@@ -1,0 +1,94 @@
+// Copyright 2020 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import yargs from 'yargs';
+
+import {getEmbeddedCompiler} from './get-embedded-compiler';
+import {getEmbeddedProtocol} from './get-embedded-protocol';
+import {getJSApi} from './get-js-api';
+
+const argv = yargs(process.argv.slice(2))
+  .option('compiler-path', {
+    type: 'string',
+    description:
+      'Build the Embedded Dart Sass binary from the source at this path.',
+  })
+  .option('compiler-ref', {
+    type: 'string',
+    description: 'Build the Embedded Dart Sass binary from this Git ref.',
+  })
+  .option('skip-compiler', {
+    type: 'boolean',
+    description: "Don't Embedded Dart Sass at all.",
+  })
+  .option('protocol-path', {
+    type: 'string',
+    description: 'Build the Embedded Protocol from the source at this path.',
+  })
+  .option('protocol-ref', {
+    type: 'string',
+    description: 'Build the Embedded Protocol from this Git ref.',
+  })
+  .option('api-path', {
+    type: 'string',
+    description: 'Use the JS API definitions from the source at this path.',
+  })
+  .option('api-ref', {
+    type: 'string',
+    description: 'Build the JS API definitions from this Git ref.',
+  })
+  .conflicts({
+    'compiler-path': ['compiler-ref', 'skip-compiler'],
+    'compiler-ref': ['skip-compiler'],
+    'protocol-path': ['protocol-ref'],
+    'api-path': 'api-ref',
+  })
+  .parseSync();
+
+(async () => {
+  try {
+    const outPath = 'lib/src/vendor';
+
+    if (argv['protocol-ref']) {
+      await getEmbeddedProtocol(outPath, {
+        ref: argv['protocol-ref'],
+      });
+    } else if (argv['protocol-path']) {
+      await getEmbeddedProtocol(outPath, {
+        path: argv['protocol-path'],
+      });
+    } else {
+      await getEmbeddedProtocol(outPath);
+    }
+
+    if (!argv['skip-compiler']) {
+      if (argv['compiler-ref']) {
+        await getEmbeddedCompiler(outPath, {
+          ref: argv['compiler-ref'],
+        });
+      } else if (argv['compiler-path']) {
+        await getEmbeddedCompiler(outPath, {
+          path: argv['compiler-path'],
+        });
+      } else {
+        await getEmbeddedCompiler(outPath);
+      }
+    }
+
+    if (argv['api-ref']) {
+      await getJSApi(outPath, {
+        ref: argv['api-ref'],
+      });
+    } else if (argv['api-path']) {
+      await getJSApi(outPath, {
+        path: argv['api-path'],
+      });
+    } else {
+      await getJSApi(outPath);
+    }
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+})();

--- a/tool/prepare-optional-release.ts
+++ b/tool/prepare-optional-release.ts
@@ -1,0 +1,137 @@
+import extractZip = require('extract-zip');
+import {promises as fs} from 'fs';
+import fetch from 'node-fetch';
+import * as p from 'path';
+import {extract as extractTar} from 'tar';
+import yargs from 'yargs';
+
+import * as pkg from '../package.json';
+import * as utils from './utils';
+
+export type DartPlatform = 'linux' | 'macos' | 'windows';
+export type DartArch = 'ia32' | 'x64' | 'arm' | 'arm64';
+
+const argv = yargs(process.argv.slice(2))
+  .option('package', {
+    type: 'string',
+    description:
+      'Directory name under `npm` directory that contains optional dependencies.',
+    demandOption: true,
+    choices: Object.keys(pkg.optionalDependencies).map(
+      name => name.split('sass-embedded-')[1]
+    ),
+  })
+  .parseSync();
+
+// Converts a Node-style platform name as returned by `process.platform` into a
+// name used by Dart Sass. Throws if the operating system is not supported by
+// Dart Sass Embedded.
+export function nodePlatformToDartPlatform(platform: string): DartPlatform {
+  switch (platform) {
+    case 'linux':
+      return 'linux';
+    case 'darwin':
+      return 'macos';
+    case 'win32':
+      return 'windows';
+    default:
+      throw Error(`Platform ${platform} is not supported.`);
+  }
+}
+
+// Converts a Node-style architecture name as returned by `process.arch` into a
+// name used by Dart Sass. Throws if the architecture is not supported by Dart
+// Sass Embedded.
+export function nodeArchToDartArch(arch: string): DartArch {
+  switch (arch) {
+    case 'ia32':
+      return 'ia32';
+    case 'x86':
+      return 'ia32';
+    case 'x64':
+      return 'x64';
+    case 'arm':
+      return 'arm';
+    case 'arm64':
+      return 'arm64';
+    default:
+      throw Error(`Architecture ${arch} is not supported.`);
+  }
+}
+
+// Get the platform's file extension for archives.
+function getArchiveExtension(platform: DartPlatform): '.zip' | '.tar.gz' {
+  return platform === 'windows' ? '.zip' : '.tar.gz';
+}
+
+// Downloads the release for `repo` located at `assetUrl`, then unzips it into
+// `outPath`.
+async function downloadRelease(options: {
+  repo: string;
+  assetUrl: string;
+  outPath: string;
+}): Promise<void> {
+  console.log(`Downloading ${options.repo} release asset.`);
+  const response = await fetch(options.assetUrl, {
+    redirect: 'follow',
+  });
+  if (!response.ok) {
+    throw Error(
+      `Failed to download ${options.repo} release asset: ${response.statusText}`
+    );
+  }
+  const releaseAsset = await response.buffer();
+
+  console.log(`Unzipping ${options.repo} release asset to ${options.outPath}.`);
+  await utils.cleanDir(p.join(options.outPath, options.repo));
+
+  const archiveExtension = options.assetUrl.endsWith('.zip')
+    ? '.zip'
+    : '.tar.gz';
+  const zippedAssetPath =
+    options.outPath + '/' + options.repo + archiveExtension;
+  await fs.writeFile(zippedAssetPath, releaseAsset);
+  if (archiveExtension === '.zip') {
+    await extractZip(zippedAssetPath, {
+      dir: p.join(process.cwd(), options.outPath),
+    });
+  } else {
+    extractTar({
+      file: zippedAssetPath,
+      cwd: options.outPath,
+      sync: true,
+    });
+  }
+  await fs.unlink(zippedAssetPath);
+}
+
+(async () => {
+  try {
+    const version = pkg['compiler-version'] as string;
+    if (version.endsWith('-dev')) {
+      throw Error(
+        "Can't release optional packages for a -dev compiler version."
+      );
+    }
+
+    const [nodePlatform, nodeArch] = argv.package.split('-');
+    const dartPlatform = nodePlatformToDartPlatform(nodePlatform);
+    const dartArch = nodeArchToDartArch(nodeArch);
+    const outPath = p.join('npm', argv.package);
+    await downloadRelease({
+      repo: 'dart-sass-embedded',
+      assetUrl:
+        'https://github.com/sass/dart-sass-embedded/releases/download/' +
+        `${version}/sass_embedded-${version}-` +
+        `${dartPlatform}-${dartArch}${getArchiveExtension(dartPlatform)}`,
+      outPath,
+    });
+    await fs.rename(
+      p.join(outPath, 'sass_embedded'),
+      p.join(outPath, 'dart-sass-embedded')
+    );
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+})();

--- a/tool/prepare-release.ts
+++ b/tool/prepare-release.ts
@@ -1,0 +1,69 @@
+// Copyright 2021 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {promises as fs} from 'fs';
+import * as shell from 'shelljs';
+
+import * as pkg from '../package.json';
+import {getEmbeddedProtocol} from './get-embedded-protocol';
+import {getJSApi} from './get-js-api';
+
+(async () => {
+  try {
+    await sanityCheckBeforeRelease();
+
+    await getEmbeddedProtocol('lib/src/vendor');
+
+    await getJSApi('lib/src/vendor');
+
+    console.log('Transpiling TS into dist.');
+    shell.exec('tsc');
+
+    console.log('Copying JS API types to dist.');
+    shell.cp('-R', 'lib/src/vendor/sass', 'dist/types');
+    await fs.unlink('dist/types/README.md');
+
+    // .gitignore needs to exist in dist for `npm publish` to correctly exclude
+    // files from the published tarball.
+    console.log('Copying .gitignore to dist.');
+    await fs.copyFile('.gitignore', 'dist/.gitignore');
+
+    console.log('Ready for publishing to npm.');
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+})();
+
+// Quick sanity checks to make sure the release we are preparing is a suitable
+// candidate for release.
+async function sanityCheckBeforeRelease() {
+  console.log('Running sanity checks before releasing.');
+  const releaseVersion = pkg.version;
+
+  const ref = process.env['GITHUB_REF'];
+  if (ref !== `refs/tags/${releaseVersion}`) {
+    throw Error(
+      `GITHUB_REF ${ref} is different than the package.json version ${releaseVersion}.`
+    );
+  }
+
+  for (const [dep, version] of Object.entries(pkg.optionalDependencies)) {
+    if (version !== releaseVersion) {
+      throw Error(
+        `optional dependency ${dep}'s version doesn't match ${releaseVersion}.`
+      );
+    }
+  }
+
+  if (releaseVersion.indexOf('-dev') > 0) {
+    throw Error(`${releaseVersion} is a dev release.`);
+  }
+
+  const versionHeader = new RegExp(`^## ${releaseVersion}$`, 'm');
+  const changelog = await fs.readFile('CHANGELOG.md', 'utf8');
+  if (!changelog.match(versionHeader)) {
+    throw Error(`There's no CHANGELOG entry for ${releaseVersion}.`);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "useUnknownInCatchVariables": false,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "lib": ["DOM"]
+  },
+  "include": [
+    "lib/**/*.ts",
+    "lib/src/vendor/embedded-protocol/embedded_sass_pb.js",
+    "tool/*.ts"
+  ],
+  "exclude": ["**/*.test.ts"]
+}


### PR DESCRIPTION
This matches the behavior of other CI tooling, and is low-risk since
the release process releases the versions from HEAD anyway. It also
eliminates the need to make empty version-only updates to the compiler
just to make logic in Dart Sass visible to the test infrastructure.

This also refactors the tool/ directory to move each individual
`getX()` function into its own file, rather than lumping them all
together in the ambiguously-named `utils.ts`. Any utils functions that
are only used in one file have been moved to that file.