### PR TITLE
Add an explicit dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    versioning-strategy: widen


### PR DESCRIPTION
This should allow dependabot to increase version constraints beyond
just the lockfile.