### PR TITLE
Use buf to compile protobufs

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,5 @@
+version: v1
+plugins:
+- plugin: es
+  out: build/embedded-protocol
+  opt: target=ts

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,5 +1,5 @@
 version: v1
 plugins:
 - plugin: es
-  out: build/embedded-protocol
+  out: lib/src/vendor
   opt: target=ts

--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,0 +1,2 @@
+version: v1
+directories: [build/embedded-protocol]

--- a/lib/src/compile.ts
+++ b/lib/src/compile.ts
@@ -6,7 +6,7 @@ import * as p from 'path';
 import {Observable} from 'rxjs';
 import * as supportsColor from 'supports-color';
 
-import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as proto from './vendor/embedded_sass_pb';
 import * as utils from './utils';
 import {AsyncEmbeddedCompiler} from './async-compiler';
 import {CompileResult, Options, SourceSpan, StringOptions} from './vendor/sass';

--- a/lib/src/deprotofy-span.ts
+++ b/lib/src/deprotofy-span.ts
@@ -4,7 +4,7 @@
 
 import {URL} from 'url';
 
-import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as proto from './vendor/embedded_sass_pb';
 import {SourceSpan} from './vendor/sass';
 import {compilerError} from './utils';
 

--- a/lib/src/dispatcher.ts
+++ b/lib/src/dispatcher.ts
@@ -10,7 +10,7 @@ import {
   OutboundResponse,
   OutboundResponseType,
 } from './messages';
-import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as proto from './vendor/embedded_sass_pb';
 import {RequestTracker} from './request-tracker';
 import {PromiseOr, compilerError, thenOr, hostError} from './utils';
 

--- a/lib/src/exception.ts
+++ b/lib/src/exception.ts
@@ -2,7 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as proto from './vendor/embedded_sass_pb';
 import {Exception as SassException, SourceSpan} from './vendor/sass';
 import {deprotofySourceSpan} from './deprotofy-span';
 

--- a/lib/src/function-registry.ts
+++ b/lib/src/function-registry.ts
@@ -7,7 +7,7 @@ import {inspect} from 'util';
 import * as types from './vendor/sass';
 import * as utils from './utils';
 import {CustomFunction} from './vendor/sass';
-import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as proto from './vendor/embedded_sass_pb';
 import {PromiseOr, catchOr, compilerError, thenOr} from './utils';
 import {Protofier} from './protofier';
 import {Value} from './value';

--- a/lib/src/importer-registry.ts
+++ b/lib/src/importer-registry.ts
@@ -8,7 +8,7 @@ import {inspect} from 'util';
 
 import * as utils from './utils';
 import {FileImporter, Importer, Options} from './vendor/sass';
-import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as proto from './vendor/embedded_sass_pb';
 import {catchOr, thenOr, PromiseOr} from './utils';
 
 /**

--- a/lib/src/message-transformer.test.ts
+++ b/lib/src/message-transformer.test.ts
@@ -6,7 +6,7 @@ import {Subject, Observable} from 'rxjs';
 
 import {expectObservableToError} from '../../test/utils';
 import {MessageTransformer} from './message-transformer';
-import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as proto from './vendor/embedded_sass_pb';
 
 describe('message transformer', () => {
   let messages: MessageTransformer;

--- a/lib/src/message-transformer.ts
+++ b/lib/src/message-transformer.ts
@@ -6,10 +6,7 @@ import {Observable, Subject} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 import {compilerError} from './utils';
-import {
-  InboundMessage,
-  OutboundMessage,
-} from './vendor/embedded-protocol/embedded_sass_pb';
+import {InboundMessage, OutboundMessage} from './vendor/embedded_sass_pb';
 
 /**
  * Encodes InboundMessages into protocol buffers and decodes protocol buffers

--- a/lib/src/messages.ts
+++ b/lib/src/messages.ts
@@ -2,10 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import {
-  InboundMessage,
-  OutboundMessage,
-} from './vendor/embedded-protocol/embedded_sass_pb';
+import {InboundMessage, OutboundMessage} from './vendor/embedded_sass_pb';
 
 // Given a message type `M` (either `InboundMessage` or `OutboundMessage`) and a
 // union of possible message cases `T`, returns all the child types `M` contains

--- a/lib/src/protofier.ts
+++ b/lib/src/protofier.ts
@@ -4,7 +4,7 @@
 
 import {OrderedMap} from 'immutable';
 
-import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as proto from './vendor/embedded_sass_pb';
 import * as utils from './utils';
 import {FunctionRegistry} from './function-registry';
 import {SassArgumentList} from './value/argument-list';

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -6,7 +6,7 @@ import {List} from 'immutable';
 import * as p from 'path';
 import * as url from 'url';
 
-import * as proto from './vendor/embedded-protocol/embedded_sass_pb';
+import * as proto from './vendor/embedded_sass_pb';
 import {Syntax} from './vendor/sass';
 
 export type PromiseOr<

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "minipass": "4.0.1",
     "node-fetch": "^3.3.0",
     "npm-run-all": "^4.1.5",
+    "path-equal": "^1.2.5",
     "shelljs": "^0.8.4",
     "source-map-js": "^1.0.2",
     "tar": "^6.0.5",

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.0.0",
-    "@bufbuild/protoc-gen-es": "^1.0.0",
     "buffer-builder": "^0.2.0",
     "immutable": "^4.0.0",
     "rxjs": "^7.4.0",
     "supports-color": "^8.1.1"
   },
   "devDependencies": {
-    "@protobuf-ts/protoc": "^2.8.2",
+    "@bufbuild/buf": "^1.13.1-4",
+    "@bufbuild/protoc-gen-es": "^1.0.0",
     "@types/buffer-builder": "^0.2.0",
     "@types/google-protobuf": "^3.7.2",
     "@types/jest": "^29.4.0",

--- a/test/dependencies.test.ts
+++ b/test/dependencies.test.ts
@@ -19,7 +19,7 @@ it('declares a compatible dependency on the embedded protocol', () => {
   expect(
     fs
       .readFileSync(
-        p.join(__dirname, '../lib/src/vendor/embedded-protocol/VERSION'),
+        p.join(__dirname, '../build/embedded-protocol/VERSION'),
         'utf-8'
       )
       .trim()

--- a/tool/get-embedded-compiler.ts
+++ b/tool/get-embedded-compiler.ts
@@ -25,10 +25,10 @@ export async function getEmbeddedCompiler(
   if (!options || 'ref' in options) {
     utils.fetchRepo({
       repo,
-      outPath: utils.BUILD_PATH,
+      outPath: 'build',
       ref: options?.ref ?? 'main',
     });
-    source = p.join(utils.BUILD_PATH, repo);
+    source = p.join('build', repo);
     await maybeOverrideSassDependency(source);
   } else {
     source = options.path;

--- a/tool/get-embedded-protocol.ts
+++ b/tool/get-embedded-protocol.ts
@@ -43,21 +43,9 @@ export async function getEmbeddedProtocol(
 
 // Builds the embedded proto at `repoPath` into a pbjs with TS declaration file.
 function buildEmbeddedProtocol(repoPath: string): void {
-  const proto = p.join(repoPath, 'embedded_sass.proto');
   const version = shell
-    .exec('npx protoc --version', {silent: true})
+    .exec('npx buf --version', {silent: true})
     .stdout.trim();
-  console.log(
-    `Building pbjs and TS declaration file from ${proto} with protoc ` +
-      `${version}.`
-  );
-
-  mkdirSync('build/embedded-protocol', {recursive: true});
-  shell.exec(
-    `npx protoc \
-      --es_out="target=ts:build/embedded-protocol" \
-      --proto_path="${repoPath}" \
-      ${proto}`,
-    {silent: true}
-  );
+  console.log(`Building TS with buf ${version}.`);
+  shell.exec(`npx buf generate`);
 }

--- a/tool/get-embedded-protocol.ts
+++ b/tool/get-embedded-protocol.ts
@@ -2,8 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import * as p from 'path';
-import {pathEqual} from 'path-equal'
+import {pathEqual} from 'path-equal';
 import * as shell from 'shelljs';
 
 import * as pkg from '../package.json';

--- a/tool/utils.ts
+++ b/tool/utils.ts
@@ -57,7 +57,7 @@ export async function link(source: string, destination: string): Promise<void> {
 export async function cleanDir(dir: string): Promise<void> {
   await fs.mkdir(p.dirname(dir), {recursive: true});
   try {
-    await fs.rmdir(dir, {recursive: true});
+    await fs.rm(dir, {force: true, recursive: true});
   } catch (_) {
     // If dir doesn't exist yet, that's fine.
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
   },
   "include": [
     "lib/**/*.ts",
-    "lib/src/vendor/embedded-protocol/embedded_sass_pb.js",
     "tool/*.ts"
   ],
   "exclude": ["**/*.test.ts"]


### PR DESCRIPTION
We were using @protobuf-ts/protoc, but that downloads protoc versions
live at runtime which causes many problems for CI. buf supports both a
standalone GitHub action and an npm installation.