### PR TITLE
Improve launch performance by skipping wrapper script

### DIFF
--- a/lib/src/async-compiler.ts
+++ b/lib/src/async-compiler.ts
@@ -6,7 +6,7 @@ import {spawn} from 'child_process';
 import {Observable} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
-import {compilerPath} from './compiler-path';
+import {compilerCommand} from './compiler-path';
 
 /**
  * An asynchronous wrapper for the embedded Sass compiler that exposes its stdio
@@ -14,7 +14,11 @@ import {compilerPath} from './compiler-path';
  */
 export class AsyncEmbeddedCompiler {
   /** The underlying process that's being wrapped. */
-  private readonly process = spawn(compilerPath, {windowsHide: true});
+  private readonly process = spawn(
+    compilerCommand[0],
+    compilerCommand.slice(1),
+    {windowsHide: true}
+  );
 
   /** The child process's exit event. */
   readonly exit$ = new Promise<number | null>(resolve => {

--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -6,8 +6,8 @@ import * as fs from 'fs';
 import * as p from 'path';
 import {isErrnoException} from './utils';
 
-/** The path to the embedded compiler executable. */
-export const compilerPath = (() => {
+/** The full command for the embedded compiler executable. */
+export const compilerCommand = (() => {
   // find for development
   for (const path of ['vendor', '../../../lib/src/vendor']) {
     const executable = p.resolve(
@@ -18,15 +18,33 @@ export const compilerPath = (() => {
       }`
     );
 
-    if (fs.existsSync(executable)) return executable;
+    if (fs.existsSync(executable)) return [executable];
   }
 
   try {
-    return require.resolve(
-      `sass-embedded-${process.platform}-${process.arch}/` +
-        'dart-sass-embedded/dart-sass-embedded' +
-        (process.platform === 'win32' ? '.bat' : '')
-    );
+    return [
+      require.resolve(
+        `sass-embedded-${process.platform}-${process.arch}/` +
+          'dart-sass-embedded/src/dart' +
+          (process.platform === 'win32' ? '.exe' : '')
+      ),
+      require.resolve(
+        `sass-embedded-${process.platform}-${process.arch}/` +
+          'dart-sass-embedded/src/dart-sass-embedded.snapshot'
+      ),
+    ];
+  } catch (ignored) {
+    // ignored
+  }
+
+  try {
+    return [
+      require.resolve(
+        `sass-embedded-${process.platform}-${process.arch}/` +
+          'dart-sass-embedded/dart-sass-embedded' +
+          (process.platform === 'win32' ? '.bat' : '')
+      ),
+    ];
   } catch (e: unknown) {
     if (!(isErrnoException(e) && e.code === 'MODULE_NOT_FOUND')) {
       throw e;

--- a/lib/src/sync-compiler.ts
+++ b/lib/src/sync-compiler.ts
@@ -5,7 +5,7 @@
 import {Subject} from 'rxjs';
 
 import {SyncProcess} from './sync-process';
-import {compilerPath} from './compiler-path';
+import {compilerCommand} from './compiler-path';
 
 /**
  * A synchronous wrapper for the embedded Sass compiler that exposes its stdio
@@ -13,7 +13,11 @@ import {compilerPath} from './compiler-path';
  */
 export class SyncEmbeddedCompiler {
   /** The underlying process that's being wrapped. */
-  private readonly process = new SyncProcess(compilerPath, {windowsHide: true});
+  private readonly process = new SyncProcess(
+    compilerCommand[0],
+    compilerCommand.slice(1),
+    {windowsHide: true}
+  );
 
   /** The buffers emitted by the child process's stdout. */
   readonly stdout$ = new Subject<Buffer>();


### PR DESCRIPTION
This PR ports https://github.com/ntkme/sass-embedded-host-ruby/compare/e14de4a89c8f8d11f42f8cc372370feca81274e7...f08525077596f20655d0cad54d20e168827ce3da, which improves the launch speed of compiler process.

In order to better measure the cost of compiler startup, all the compilations are done sequentially. Test is done on M1 Macbook Pro. Results may vary depends on the platform, but all platforms should see faster launch.

Before:
```
500 compileStringAsync took 11480.290958046913 milliseconds.
500 compileString took 21916.757833003998 milliseconds.
```

After:
```
500 compileStringAsync took 8629.174999952316 milliseconds.
500 compileString took 19083.104707956314 milliseconds.
```

Benchmark script:
``` js
const sass = require('sass-embedded');

async function benchmark (n) {
  const t0 = performance.now();

  for (let i = 0; i < n; i++) {
    await sass.compileStringAsync('a{b:c}');
  }

  const t1 = performance.now();

  console.log(`${n} compileStringAsync took ${t1 - t0} milliseconds.`);

  const t2 = performance.now();

  for (let i = 0; i < n; i++) {
    sass.compileString('a{b:c}');
  }

  const t3 = performance.now();

  console.log(`${n} compileString took ${t3 - t2} milliseconds.`);
}

benchmark(process.argv[2] || 500);
```