### PR TITLE
Fix resolving against the working directory in legacy API

### DIFF
--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -83,6 +83,10 @@ function adjustOptions<sync extends 'sync' | 'async'>(
     throw new Error('Either options.data or options.file must be set.');
   }
 
+  // In legacy API, the current working directory is always attempted before
+  // any load path.
+  options.includePaths = [process.cwd(), ...(options.includePaths ?? [])];
+
   if (
     !isStringOptions(options) &&
     // The `indentedSyntax` option takes precedence over the file extension in the
@@ -200,9 +204,7 @@ function pluginThis(
       context: undefined as unknown as LegacyPluginThis,
       file: options.file,
       data: options.data,
-      includePaths: [process.cwd(), ...(options.includePaths ?? [])].join(
-        p.delimiter
-      ),
+      includePaths: (options.includePaths ?? []).join(p.delimiter),
       precision: 10,
       style: 1,
       indentType: 0,


### PR DESCRIPTION
The issue here is that currently `process.cwd()` is added in `pluginThis`, causing it to be missing in actual `loadPaths`.
This PR modifies the logic to add `process.cwd()` in `adjustOptions` so that it affect actual `loadPaths`.

- Fixes https://github.com/sass/dart-sass/issues/1920

https://github.com/sass/sass-spec/pull/1893