### PR TITLE
fix: resolve.require could not find the target path

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -5,6 +5,7 @@
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
+  "main": "./dart-sass-embedded/dart-sass-embedded",
   "files": [
     "dart-sass-embedded/**/*"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -5,6 +5,7 @@
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
+  "main": "./dart-sass-embedded/dart-sass-embedded",
   "files": [
     "dart-sass-embedded/**/*"
   ],

--- a/npm/linux-arm/package.json
+++ b/npm/linux-arm/package.json
@@ -5,6 +5,7 @@
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
+  "main": "./dart-sass-embedded/dart-sass-embedded",
   "files": [
     "dart-sass-embedded/**/*"
   ],

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -5,6 +5,7 @@
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
+  "main": "./dart-sass-embedded/dart-sass-embedded",
   "files": [
     "dart-sass-embedded/**/*"
   ],

--- a/npm/linux-ia32/package.json
+++ b/npm/linux-ia32/package.json
@@ -5,6 +5,7 @@
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
+  "main": "./dart-sass-embedded/dart-sass-embedded",
   "files": [
     "dart-sass-embedded/**/*"
   ],

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -5,6 +5,7 @@
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
+  "main": "./dart-sass-embedded/dart-sass-embedded",
   "files": [
     "dart-sass-embedded/**/*"
   ],

--- a/npm/win32-ia32/package.json
+++ b/npm/win32-ia32/package.json
@@ -5,6 +5,7 @@
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
+  "main": "./dart-sass-embedded/dart-sass-embedded.bat",
   "files": [
     "dart-sass-embedded/**/*"
   ],

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -5,6 +5,7 @@
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
+  "main": "./dart-sass-embedded/dart-sass-embedded.bat",
   "files": [
     "dart-sass-embedded/**/*"
   ],


### PR DESCRIPTION
```js
let path  = resolve.require('sass-embedded-darwin-arm64'); // not found
```
Because the algorithm is looking for the `main` field in the `package.json` file.