### PR TITLE
Revert "Bump minipass from 4.2.5 to 6.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "extract-zip": "^2.0.1",
     "gts": "^4.0.0",
     "jest": "^29.4.1",
-    "minipass": "6.0.0",
+    "minipass": "4.2.5",
     "npm-run-all": "^4.1.5",
     "path-equal": "^1.2.5",
     "shelljs": "^0.8.4",


### PR DESCRIPTION
Reverts sass/embedded-host-node#219

Breaks `npm run compile` in my machine (not sure why tests passed tho)

It's a known issue: https://github.com/isaacs/minipass/issues/49