### PR TITLE
Legacy importer wrapper only searches for relative URLs if the URL is not canonicalized

### DIFF
--- a/lib/src/legacy/importer.ts
+++ b/lib/src/legacy/importer.ts
@@ -125,7 +125,9 @@ export class LegacyImporterWrapper<sync extends 'sync' | 'async'>
 
       this.expectingRelativeLoad = false;
       return null;
-    } else {
+    } else if (!url.startsWith('file:')) {
+      // We'll only search for another relative import when the URL isn't
+      // canonicalized already.
       this.expectingRelativeLoad = true;
     }
 

--- a/lib/src/legacy/importer.ts
+++ b/lib/src/legacy/importer.ts
@@ -127,7 +127,7 @@ export class LegacyImporterWrapper<sync extends 'sync' | 'async'>
       return null;
     } else if (!url.startsWith('file:')) {
       // We'll only search for another relative import when the URL isn't
-      // canonicalized already.
+      // absolute.
       this.expectingRelativeLoad = true;
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,14 +8,9 @@
     "useUnknownInCatchVariables": false,
     "resolveJsonModule": true,
     "declaration": false,
-    "lib": ["DOM"]
+    "lib": ["DOM"],
+    "skipLibCheck": true
   },
-  "include": [
-    "lib/**/*.ts",
-    "tool/*.ts"
-  ],
-  "exclude": [
-    "**/*.test.ts",
-    "lib/src/vendor/dart-sass/**"
-  ]
+  "include": ["lib/**/*.ts", "tool/*.ts"],
+  "exclude": ["**/*.test.ts", "lib/src/vendor/dart-sass/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,14 @@
     "useUnknownInCatchVariables": false,
     "resolveJsonModule": true,
     "declaration": false,
-    "lib": ["DOM"],
-    "skipLibCheck": true
+    "lib": ["DOM"]
   },
-  "include": ["lib/**/*.ts", "tool/*.ts"],
-  "exclude": ["**/*.test.ts", "lib/src/vendor/dart-sass/**"]
+  "include": [
+    "lib/**/*.ts",
+    "tool/*.ts"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "lib/src/vendor/dart-sass/**"
+  ]
 }


### PR DESCRIPTION
Specs: https://github.com/sass/sass-spec/pull/1910

Fixes: https://github.com/sass/dart-sass/issues/1962

Changelog: https://github.com/sass/dart-sass/pull/1992