### PR TITLE
Fixed exports paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "author": "Google Inc.",
   "license": "MIT",
   "exports": {
-    "import": "dist/lib/index.mjs",
-    "default": "dist/lib/index.js"
+    "import": "./dist/lib/index.mjs",
+    "default": "./dist/lib/index.js"
   },
   "main": "dist/lib/index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
Fixed exports paths in package.json - they have to start with ./ according to https://nodejs.org/api/packages.html#exports

The current paths break the build when using sass-loader with sass-embedded and webpack 5.86.0:
`[webpack-cli] Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "dist/lib/index.js" defined in the package config /home/runner/.../node_modules/sass-embedded/package.json; targets must start with "./"`