### PR TITLE
fix Invalid "exports" target "dist/lib/index.js"

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "author": "Google Inc.",
   "license": "MIT",
   "exports": {
-    "import": "dist/lib/index.mjs",
-    "default": "dist/lib/index.js"
+    "import": "./dist/lib/index.mjs",
+    "default": "./dist/lib/index.js"
   },
   "main": "dist/lib/index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
error message:
Invalid "exports" target "dist/lib/index.js" defined in the package config; targets must start with "./"