### PR TITLE
Workaround for shelljs in windows to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,6 @@ jobs:
         uses: sass/clone-linked-repo@v1
         with: {repo: sass/sass, path: language}
 
-      # Workaround for https://github.com/shelljs/shelljs/issues/198
-      - run: rm language/spec/README.md
-
       - run: npm install
       - name: npm run init
         run: |
@@ -109,9 +106,6 @@ jobs:
       - name: Check out the language repo
         uses: sass/clone-linked-repo@v1
         with: {repo: sass/sass, path: language}
-
-      # Workaround for https://github.com/shelljs/shelljs/issues/198
-      - run: rm language/spec/README.md
 
       - run: npm install
       - name: npm run init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
         uses: sass/clone-linked-repo@v1
         with: {repo: sass/sass, path: language}
 
+      # Workaround for https://github.com/shelljs/shelljs/issues/198
+      - run: rm language/spec/README.md
+
       - run: npm install
       - name: npm run init
         run: |
@@ -106,6 +109,9 @@ jobs:
       - name: Check out the language repo
         uses: sass/clone-linked-repo@v1
         with: {repo: sass/sass, path: language}
+
+      # Workaround for https://github.com/shelljs/shelljs/issues/198
+      - run: rm language/spec/README.md
 
       - run: npm install
       - name: npm run init

--- a/tool/get-language-repo.ts
+++ b/tool/get-language-repo.ts
@@ -27,6 +27,11 @@ export async function getLanguageRepo(
   } else {
     await utils.cleanDir('build/sass');
     await utils.link(options.path, 'build/sass');
+
+    // Workaround for https://github.com/shelljs/shelljs/issues/198
+    // This file is a symlink which gets messed up by `shell.cp` (called from
+    // `utils.link`) on Windows.
+    shell.rm('build/sass/spec/README.md');
   }
 
   await utils.link('build/sass/js-api-doc', p.join(outPath, 'sass'));


### PR DESCRIPTION
`shell.cp()` creates invalid symlinks when copying directories in Windows.
See: https://github.com/shelljs/shelljs/issues/198