### PR TITLE
Remove README symlink when cloning sass/sass.

### DIFF
--- a/tool/get-language-repo.ts
+++ b/tool/get-language-repo.ts
@@ -27,12 +27,12 @@ export async function getLanguageRepo(
   } else {
     await utils.cleanDir('build/sass');
     await utils.link(options.path, 'build/sass');
-
-    // Workaround for https://github.com/shelljs/shelljs/issues/198
-    // This file is a symlink which gets messed up by `shell.cp` (called from
-    // `utils.link`) on Windows.
-    shell.rm('build/sass/spec/README.md');
   }
+
+  // Workaround for https://github.com/shelljs/shelljs/issues/198
+  // This file is a symlink which gets messed up by `shell.cp` (called from
+  // `utils.link`) on Windows.
+  shell.rm('build/sass/spec/README.md');
 
   await utils.link('build/sass/js-api-doc', p.join(outPath, 'sass'));
 


### PR DESCRIPTION
Workaround for shelljs issue in Windows: https://github.com/shelljs/shelljs/issues/198