### PR TITLE
Avoid relying on buggy import order in the legacy importer

### DIFF
--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -4,7 +4,7 @@
 
 import * as fs from 'fs';
 import * as p from 'path';
-import {URL} from 'url';
+import {pathToFileURL, URL} from 'url';
 
 import {Exception} from '../exception';
 import {
@@ -181,7 +181,9 @@ function convertStringOptions<sync extends 'sync' | 'async'>(
   return {
     ...modernOptions,
     url: options.file
-      ? pathToLegacyFileUrl(options.file)
+      ? options.importer
+        ? pathToLegacyFileUrl(options.file)
+        : pathToFileURL(options.file)
       : new URL(legacyImporterProtocol),
     importer: modernOptions.importers ? modernOptions.importers[0] : undefined,
     syntax: options.indentedSyntax ? 'indented' : 'scss',

--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -4,7 +4,7 @@
 
 import * as fs from 'fs';
 import * as p from 'path';
-import {URL, pathToFileURL} from 'url';
+import {URL} from 'url';
 
 import {Exception} from '../exception';
 import {
@@ -33,11 +33,13 @@ import {
   StringOptions,
 } from '../vendor/sass';
 import {wrapFunction} from './value/wrap';
+import {endOfLoadProtocol, LegacyImporterWrapper} from './importer';
 import {
-  endOfLoadProtocol,
   legacyImporterProtocol,
-  LegacyImporterWrapper,
-} from './importer';
+  pathToLegacyFileUrl,
+  removeLegacyImporter,
+  removeLegacyImporterFromSpan,
+} from './utils';
 
 export function render(
   options: LegacyOptions<'async'>,
@@ -74,8 +76,8 @@ export function renderSync(options: LegacyOptions<'sync'>): LegacyResult {
   }
 }
 
-// Does some initial adjustments of `options` to make it easier to convert pass
-// to the new API.
+// Does some initial adjustments of `options` to make it easier to pass to the
+// new API.
 function adjustOptions<sync extends 'sync' | 'async'>(
   options: LegacyOptions<sync>
 ): LegacyOptions<sync> {
@@ -119,7 +121,7 @@ function isStringOptions<sync extends 'sync' | 'async'>(
 function convertOptions<sync extends 'sync' | 'async'>(
   options: LegacyOptions<sync>,
   sync: SyncBoolean<sync>
-): Options<sync> {
+): Options<sync> & {legacy: true} {
   if (
     'outputStyle' in options &&
     options.outputStyle !== 'compressed' &&
@@ -165,6 +167,7 @@ function convertOptions<sync extends 'sync' | 'async'>(
     verbose: options.verbose,
     charset: options.charset,
     logger: options.logger,
+    legacy: true,
   };
 }
 
@@ -172,13 +175,13 @@ function convertOptions<sync extends 'sync' | 'async'>(
 function convertStringOptions<sync extends 'sync' | 'async'>(
   options: LegacyStringOptions<sync>,
   sync: SyncBoolean<sync>
-): StringOptions<sync> {
+): StringOptions<sync> & {legacy: true} {
   const modernOptions = convertOptions(options, sync);
 
   return {
     ...modernOptions,
     url: options.file
-      ? pathToFileURL(options.file)
+      ? pathToLegacyFileUrl(options.file)
       : new URL(legacyImporterProtocol),
     importer: modernOptions.importers ? modernOptions.importers[0] : undefined,
     syntax: options.indentedSyntax ? 'indented' : 'scss',
@@ -256,12 +259,11 @@ function newLegacyResult(
     sourceMap.sources = sourceMap.sources
       .filter(source => !source.startsWith(endOfLoadProtocol))
       .map(source => {
+        source = removeLegacyImporter(source);
         if (source.startsWith('file://')) {
           return pathToUrlString(
             p.relative(sourceMapDir, fileUrlToPathCrossPlatform(source))
           );
-        } else if (source.startsWith(legacyImporterProtocol)) {
-          return source.substring(legacyImporterProtocol.length);
         } else if (source.startsWith('data:')) {
           return 'stdin';
         } else {
@@ -299,13 +301,10 @@ function newLegacyResult(
       includedFiles: result.loadedUrls
         .filter(url => url.protocol !== endOfLoadProtocol)
         .map(url => {
-          if (url.protocol === 'file:') {
-            return fileUrlToPathCrossPlatform(url as URL);
-          } else if (url.protocol === legacyImporterProtocol) {
-            return decodeURI(url.pathname);
-          } else {
-            return url.toString();
-          }
+          const urlString = removeLegacyImporter(url.toString());
+          return urlString.startsWith('file:')
+            ? fileUrlToPathCrossPlatform(urlString)
+            : urlString;
         }),
     },
   };
@@ -321,25 +320,27 @@ function newLegacyException(error: Error): LegacyException {
     });
   }
 
+  const span = error.span ? removeLegacyImporterFromSpan(error.span) : null;
   let file: string;
-  if (!error.span?.url) {
+  if (!span?.url) {
     file = 'stdin';
-  } else if (error.span.url.protocol === 'file:') {
+  } else if (span.url.protocol === 'file:') {
     // We have to cast to Node's URL type here because the specified type is the
     // standard URL type which is slightly less featureful. `fileURLToPath()`
     // does work with standard URL objects in practice, but we know that we
     // generate Node URLs here regardless.
-    file = fileUrlToPathCrossPlatform(error.span.url as URL);
+    file = fileUrlToPathCrossPlatform(span.url as URL);
   } else {
-    file = error.span.url.toString();
+    file = span.url.toString();
   }
 
+  const errorString = removeLegacyImporter(error.toString());
   return Object.assign(new Error(), {
     status: 1,
-    message: error.toString().replace(/^Error: /, ''),
-    formatted: error.toString(),
-    toString: () => error.toString(),
-    stack: error.stack,
+    message: errorString.replace(/^Error: /, ''),
+    formatted: errorString,
+    toString: () => errorString,
+    stack: error.stack ? removeLegacyImporter(error.stack) : undefined,
     line: isNullOrUndefined(error.span?.start.line)
       ? undefined
       : error.span!.start.line + 1,

--- a/lib/src/legacy/index.ts
+++ b/lib/src/legacy/index.ts
@@ -303,6 +303,10 @@ function newLegacyResult(
       includedFiles: result.loadedUrls
         .filter(url => url.protocol !== endOfLoadProtocol)
         .map(url => {
+          if (url.protocol === legacyImporterProtocol) {
+            return decodeURI(url.pathname);
+          }
+
           const urlString = removeLegacyImporter(url.toString());
           return urlString.startsWith('file:')
             ? fileUrlToPathCrossPlatform(urlString)

--- a/lib/src/legacy/utils.ts
+++ b/lib/src/legacy/utils.ts
@@ -1,0 +1,59 @@
+// Copyright 2023 Google Inc. Use of this source code is governed by an
+// MIT-style license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import {strict as assert} from 'assert';
+import {pathToFileURL} from 'url';
+
+import {fileUrlToPathCrossPlatform} from '../utils';
+import {SourceSpan} from '../vendor/sass';
+import {legacyImporterFileProtocol} from './importer';
+
+/**
+ * The URL protocol to use for URLs canonicalized using `LegacyImporterWrapper`.
+ */
+export const legacyImporterProtocol = 'legacy-importer:';
+
+/**
+ * The prefix for absolute URLs canonicalized using `LegacyImporterWrapper`.
+ *
+ * This is used to distinguish imports resolved relative to URLs returned by a
+ * legacy importer from manually-specified absolute URLs.
+ */
+export const legacyImporterProtocolPrefix = 'legacy-importer-';
+
+/// A regular expression that matches legacy importer protocol syntax that
+/// should be removed from human-readable messages.
+const removeLegacyImporterRegExp = new RegExp(
+  `${legacyImporterProtocol}|${legacyImporterProtocolPrefix}`,
+  'g'
+);
+
+/// Returns `string` with all instances of legacy importer syntax removed.
+export function removeLegacyImporter(string: string): string {
+  return string.replace(removeLegacyImporterRegExp, '');
+}
+
+/// Returns a copy of [span] with the URL updated to remove legacy importer
+/// syntax.
+export function removeLegacyImporterFromSpan(span: SourceSpan): SourceSpan {
+  if (!span.url) return span;
+  return {...span, url: new URL(removeLegacyImporter(span.url.toString()))};
+}
+
+/// Converts [path] to a `file:` URL and adds the [legacyImporterProtocolPrefix]
+/// to the beginning so we can distinguish it from manually-specified absolute
+/// `file:` URLs.
+export function pathToLegacyFileUrl(path: string): URL {
+  return new URL(`${legacyImporterProtocolPrefix}${pathToFileURL(path)}`);
+}
+
+/// Converts a `file:` URL with [legacyImporterProtocolPrefix] to the filesystem
+/// path which it represents.
+export function legacyFileUrlToPath(url: URL): string {
+  assert.equal(url.protocol, legacyImporterFileProtocol);
+  const originalUrl = url
+    .toString()
+    .substring(legacyImporterProtocolPrefix.length);
+  return fileUrlToPathCrossPlatform(originalUrl);
+}


### PR DESCRIPTION
Historically, the legacy importer shim has strongly assumed that all
calls to `canonicalize()` would doubled: once as a URL resolved
relative to the current importer, and again as a URL passed to the
importers list. However, this relies on buggy, non-spec-compliant
behavior in Dart Sass: absolute URLs should never be passed to the
current importer, only to the global list of importers.

This change avoids relying on that behavior by instead disambiguating
relative loads using a custom URL protocol prefix. All canonical URLs
passed to Dart Sass now have the prefix `legacy-importer-` added to
the beginning. This allows us to disambiguate relative loads, and
ignore them for non-`file:` URLs, since relative loads and _only_
relative loads will have schemes beginning with `legacy-importer-`.

To avoid regressing the developer experience, we then strip these
prefixes from all URLs before they're passed to any developer-facing
APIs or displayed to the user.

See sass/sass-spec#1935
See sass/dart-sass#2077