### PR TITLE
Properly include and export TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-embedded",
-  "version": "1.67.0",
+  "version": "1.67.1-dev",
   "protocol-version": "2.1.0",
   "compiler-version": "1.67.0",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
@@ -8,7 +8,11 @@
   "author": "Google Inc.",
   "license": "MIT",
   "exports": {
-    "import": "./dist/lib/index.mjs",
+    "import": {
+      "types": "./dist/lib/index.m.d.ts",
+      "default": "./dist/lib/index.mjs"
+    },
+    "types": "./dist/lib/index.d.ts",
     "default": "./dist/lib/index.js"
   },
   "main": "dist/lib/index.js",
@@ -25,7 +29,7 @@
     "check:gts": "gts check",
     "check:tsc": "tsc --noEmit",
     "clean": "gts clean",
-    "compile": "tsc && cp lib/index.mjs dist/lib/index.mjs",
+    "compile": "tsc && cp lib/index.mjs dist/lib/index.mjs && cp -r lib/src/vendor/sass/ dist/lib/src/vendor/sass && cp dist/lib/src/vendor/sass/index.d.ts dist/lib/src/vendor/sass/index.m.d.ts",
     "fix": "gts fix",
     "prepublishOnly": "npm run clean && ts-node ./tool/prepare-release.ts",
     "test": "jest"


### PR DESCRIPTION
We need to copy the entrypoing typings file, as described in [the
TypeScript docs]:

> It’s important to note that the CommonJS entrypoint and the ES
> module entrypoint each needs its own declaration file, even if the
> contents are the same between them. Every declaration file is
> interpreted either as a CommonJS module or as an ES module, based on
> its file extension and the `"type"` field of the `package.json`, and
> this detected module kind must match the module kind that Node will
> detect for the corresponding JavaScript file for type checking to be
> correct. Attempting to use a single `.d.ts` file to type both an ES
> module entrypoint and a CommonJS entrypoint will cause TypeScript to
> think only one of those entrypoints exists, causing compiler errors
> for users of the package.

[the TypeScript docs]: https://www.typescriptlang.org/docs/handbook/esm-node.html

Closes #247