### PR TITLE
Update protocol-version to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sass-embedded",
   "version": "1.68.0",
-  "protocol-version": "2.1.0",
+  "protocol-version": "2.2.0",
   "compiler-version": "1.68.0",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
   "repository": "sass/embedded-host-node",


### PR DESCRIPTION
The 1.68.0 release failed due to mismatched protocol-version. This PR fixes that.

On the other hand, I wonder if we should automatically update the protocol-version in package.json as part of the dart-sass release process when GitHub Action commits to this repo. 