### PR TITLE
Use lts/* and lts/-n for node version; work around Node breaking change.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ defaults:
 
 env:
   PROTOC_VERSION: 3.x
-  DEFAULT_NODE_VERSION: 20.x # If changing this, also change jobs.tests.strategy.matrix.node_version
 
 on:
   push:
@@ -22,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          node-version: 'lts/*'
           check-latest: true
 
       - name: Check out the language repo
@@ -43,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        node-version: [20.x, 18.x, 16.x] # If changing this, also change env.DEFAULT_NODE_VERSION
+        node-version: ['lts/*', 'lts/-1', 'lts/-2']
       fail-fast: false
 
     steps:
@@ -73,9 +72,6 @@ jobs:
       - run: npm run compile
       - run: node test/after-compile-test.mjs
 
-  # The versions should be kept up-to-date with the latest LTS Node releases.
-  # They next need to be rotated October 2021. See
-  # https://github.com/nodejs/Release.
   sass_spec:
     name: 'JS API Tests | Node ${{ matrix.node_version }} | ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}-latest
@@ -84,13 +80,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        node_version: [20]
+        node_version: ['lts/*']
         include:
           # Include LTS versions on Ubuntu
           - os: ubuntu
-            node_version: 18
+            node_version: lts/-1
           - os: ubuntu
-            node_version: 16
+            node_version: lts/-2
 
     steps:
       - uses: actions/checkout@v2
@@ -147,7 +143,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          node-version: 'lts/*'
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
       - run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ defaults:
 
 env:
   PROTOC_VERSION: 3.x
-  DEFAULT_NODE_VERSION: 18.x # If changing this, also change jobs.tests.strategy.matrix.node_version
+  DEFAULT_NODE_VERSION: 20.x # If changing this, also change jobs.tests.strategy.matrix.node_version
 
 on:
   push:
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        node-version: [18.x, 16.x, 14.x] # If changing this, also change env.DEFAULT_NODE_VERSION
+        node-version: [20.x, 18.x, 16.x] # If changing this, also change env.DEFAULT_NODE_VERSION
       fail-fast: false
 
     steps:
@@ -84,13 +84,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        node_version: [18]
+        node_version: [20]
         include:
           # Include LTS versions on Ubuntu
           - os: ubuntu
-            node_version: 16
+            node_version: 18
           - os: ubuntu
-            node_version: 14
+            node_version: 16
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
           check-latest: true
@@ -46,8 +46,8 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
@@ -89,10 +89,10 @@ jobs:
             node_version: lts/-2
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with: {sdk: stable}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with: {node-version: "${{ matrix.node_version }}"}
 
       - name: Check out Dart Sass
@@ -140,8 +140,8 @@ jobs:
     needs: [static_analysis, tests, sass_spec]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
           check-latest: true

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -5,12 +5,12 @@ export const compileAsync = sass.compileAsync;
 export const compileString = sass.compileString;
 export const compileStringAsync = sass.compileStringAsync;
 export const Logger = sass.Logger;
-export const CalculationInterpolation = sass.CalculationInterpolation
-export const CalculationOperation = sass.CalculationOperation
-export const CalculationOperator = sass.CalculationOperator
+export const CalculationInterpolation = sass.CalculationInterpolation;
+export const CalculationOperation = sass.CalculationOperation;
+export const CalculationOperator = sass.CalculationOperator;
 export const SassArgumentList = sass.SassArgumentList;
 export const SassBoolean = sass.SassBoolean;
-export const SassCalculation = sass.SassCalculation
+export const SassCalculation = sass.SassCalculation;
 export const SassColor = sass.SassColor;
 export const SassFunction = sass.SassFunction;
 export const SassMixin = sass.SassMixin;
@@ -39,8 +39,9 @@ function defaultExportDeprecation() {
   if (printedDefaultExportDeprecation) return;
   printedDefaultExportDeprecation = true;
   console.error(
-      "`import sass from 'sass'` is deprecated.\n" +
-      "Please use `import * as sass from 'sass'` instead.");
+    "`import sass from 'sass'` is deprecated.\n" +
+      "Please use `import * as sass from 'sass'` instead."
+  );
 }
 
 export default {

--- a/lib/src/utils.test.ts
+++ b/lib/src/utils.test.ts
@@ -5,6 +5,8 @@ describe('utils', () => {
   describe('pathToUrlString', () => {
     it('encode relative path like `pathToFileURL`', () => {
       const baseURL = pathToFileURL('').toString();
+      // Skip charcodes 0-32 to work around Node trailing whitespace regression:
+      // https://github.com/nodejs/node/issues/51167
       for (let i = 33; i < 128; i++) {
         const char = String.fromCharCode(i);
         const filename = `${i}-${char}`;

--- a/lib/src/utils.test.ts
+++ b/lib/src/utils.test.ts
@@ -5,7 +5,7 @@ describe('utils', () => {
   describe('pathToUrlString', () => {
     it('encode relative path like `pathToFileURL`', () => {
       const baseURL = pathToFileURL('').toString();
-      for (let i = 0; i < 128; i++) {
+      for (let i = 33; i < 128; i++) {
         const char = String.fromCharCode(i);
         const filename = `${i}-${char}`;
         expect(pathToUrlString(filename)).toEqual(

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dist/**/*"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "init": "ts-node ./tool/init.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "resolveJsonModule": true,
     "rootDir": ".",
     "useUnknownInCatchVariables": false,
-    "resolveJsonModule": true,
     "declaration": false,
     "lib": ["DOM"]
   },


### PR DESCRIPTION
~~This is mostly serving as a PR to test whether the [failing Node tests](https://github.com/sass/embedded-host-node/actions/runs/7088513717/job/19522337184) are also failing on `main` -- though I'm seeing them fail locally on `main`, so I suspect it's unrelated to the changes in #260.~~

This updates Node versions in CI, fixes a few code style typos, and works around a [Node regression](https://github.com/nodejs/node/issues/51167).