### PR TITLE
Support musl-libc and android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
         run: |
-          for pkg in linux-arm linux-arm64 linux-ia32 linux-x64 darwin-arm64 darwin-x64 win32-ia32 win32-x64; do
-            npx ts-node ./tool/prepare-optional-release.ts --package=$pkg && npm publish ./npm/$pkg
-          done
+          find ./npm -mindepth 1 -maxdepth 1 -print0 | xargs -0 -n 1 -- sh -xc 'npx ts-node ./tool/prepare-optional-release.ts --package=$(basename $1) && npm publish $1' --
 
       - run: npm publish
         env:

--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -6,6 +6,10 @@ import * as fs from 'fs';
 import * as p from 'path';
 import {isErrnoException} from './utils';
 
+/**
+ * Detect if the current running node binary is linked with musl libc by
+ * checking if the binary contains a string like "/.../ld-musl-$ARCH.so"
+ */
 const isLinuxMusl = function () {
   return fs.readFileSync(process.execPath).includes('/ld-musl-');
 };

--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -12,21 +12,18 @@ const isLinuxMusl = function () {
 
 /** The full command for the embedded compiler executable. */
 export const compilerCommand = (() => {
-  let platform = process.platform as string;
-  let arch = process.arch;
-
-  if (platform === 'linux' && isLinuxMusl()) {
-    platform = 'linux-musl';
-  }
+  const platform =
+    process.platform === 'linux' && isLinuxMusl()
+      ? 'linux-musl'
+      : (process.platform as string);
 
   // https://github.com/sass/embedded-host-node/issues/263
   // Use windows-x64 emulation on windows-arm64
   //
   // TODO: Make sure to remove "arm64" from "npm/win32-x64/package.json" when
   // this logic is removed once we have true windows-arm64 support.
-  if (platform === 'win32' && arch === 'arm64') {
-    arch = 'x64';
-  }
+  const arch =
+    platform === 'win32' && process.arch === 'arm64' ? 'x86' : process.arch;
 
   // find for development
   for (const path of ['vendor', '../../../lib/src/vendor']) {

--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -6,14 +6,34 @@ import * as fs from 'fs';
 import * as p from 'path';
 import {isErrnoException} from './utils';
 
+const isLinuxMusl = function () {
+  return fs.readFileSync(process.execPath).includes('/ld-musl-');
+};
+
 /** The full command for the embedded compiler executable. */
 export const compilerCommand = (() => {
+  let platform = process.platform as string;
+  let arch = process.arch;
+
+  if (platform === 'linux' && isLinuxMusl()) {
+    platform = 'linux-musl';
+  }
+
+  // https://github.com/sass/embedded-host-node/issues/263
+  // Use windows-x64 emulation on windows-arm64
+  //
+  // TODO: Make sure to remove "arm64" from "npm/win32-x64/package.json" when
+  // this logic is removed once we have true windows-arm64 support.
+  if (platform === 'win32' && arch === 'arm64') {
+    arch = 'x64';
+  }
+
   // find for development
   for (const path of ['vendor', '../../../lib/src/vendor']) {
     const executable = p.resolve(
       __dirname,
       path,
-      `dart-sass/sass${process.platform === 'win32' ? '.bat' : ''}`
+      `dart-sass/sass${platform === 'win32' ? '.bat' : ''}`
     );
 
     if (fs.existsSync(executable)) return [executable];
@@ -22,13 +42,11 @@ export const compilerCommand = (() => {
   try {
     return [
       require.resolve(
-        `sass-embedded-${process.platform}-${process.arch}/` +
-          'dart-sass/src/dart' +
-          (process.platform === 'win32' ? '.exe' : '')
+        `sass-embedded-${platform}-${arch}/dart-sass/src/dart` +
+          (platform === 'win32' ? '.exe' : '')
       ),
       require.resolve(
-        `sass-embedded-${process.platform}-${process.arch}/` +
-          'dart-sass/src/sass.snapshot'
+        `sass-embedded-${platform}-${arch}/dart-sass/src/sass.snapshot`
       ),
     ];
   } catch (ignored) {
@@ -38,9 +56,8 @@ export const compilerCommand = (() => {
   try {
     return [
       require.resolve(
-        `sass-embedded-${process.platform}-${process.arch}/` +
-          'dart-sass/sass' +
-          (process.platform === 'win32' ? '.bat' : '')
+        `sass-embedded-${platform}-${arch}/dart-sass/sass` +
+          (platform === 'win32' ? '.bat' : '')
       ),
     ];
   } catch (e: unknown) {
@@ -52,7 +69,7 @@ export const compilerCommand = (() => {
   throw new Error(
     "Embedded Dart Sass couldn't find the embedded compiler executable. " +
       'Please make sure the optional dependency ' +
-      `sass-embedded-${process.platform}-${process.arch} is installed in ` +
+      `sass-embedded-${platform}-${arch} is installed in ` +
       'node_modules.'
   );
 })();

--- a/npm/android-arm/README.md
+++ b/npm/android-arm/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-android-arm`
+
+This is the **android-arm** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/android-arm/package.json
+++ b/npm/android-arm/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-embedded-win32-x64",
+  "name": "sass-embedded-android-arm",
   "version": "1.69.5",
-  "description": "The win32-x64 binary for sass-embedded",
+  "description": "The android-arm binary for sass-embedded",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
@@ -12,13 +12,12 @@
     "node": ">=14.0.0"
   },
   "bin": {
-    "sass": "./dart-sass/sass.bat"
+    "sass": "./dart-sass/sass"
   },
   "os": [
-    "win32"
+    "android"
   ],
   "cpu": [
-    "arm64",
-    "x64"
+    "arm"
   ]
 }

--- a/npm/android-arm64/README.md
+++ b/npm/android-arm64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-android-arm64`
+
+This is the **android-arm64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/android-arm64/package.json
+++ b/npm/android-arm64/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-embedded-win32-x64",
+  "name": "sass-embedded-android-arm64",
   "version": "1.69.5",
-  "description": "The win32-x64 binary for sass-embedded",
+  "description": "The android-arm64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
@@ -12,13 +12,12 @@
     "node": ">=14.0.0"
   },
   "bin": {
-    "sass": "./dart-sass/sass.bat"
+    "sass": "./dart-sass/sass"
   },
   "os": [
-    "win32"
+    "android"
   ],
   "cpu": [
-    "arm64",
-    "x64"
+    "arm64"
   ]
 }

--- a/npm/android-ia32/README.md
+++ b/npm/android-ia32/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-android-ia32`
+
+This is the **android-ia32** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/android-ia32/package.json
+++ b/npm/android-ia32/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-embedded-win32-x64",
+  "name": "sass-embedded-android-ia32",
   "version": "1.69.5",
-  "description": "The win32-x64 binary for sass-embedded",
+  "description": "The android-ia32 binary for sass-embedded",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
@@ -12,13 +12,12 @@
     "node": ">=14.0.0"
   },
   "bin": {
-    "sass": "./dart-sass/sass.bat"
+    "sass": "./dart-sass/sass"
   },
   "os": [
-    "win32"
+    "android"
   ],
   "cpu": [
-    "arm64",
-    "x64"
+    "ia32"
   ]
 }

--- a/npm/android-x64/README.md
+++ b/npm/android-x64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-android-x64`
+
+This is the **android-x64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/android-x64/package.json
+++ b/npm/android-x64/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-embedded-win32-x64",
+  "name": "sass-embedded-android-x64",
   "version": "1.69.5",
-  "description": "The win32-x64 binary for sass-embedded",
+  "description": "The android-x64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
@@ -12,13 +12,12 @@
     "node": ">=14.0.0"
   },
   "bin": {
-    "sass": "./dart-sass/sass.bat"
+    "sass": "./dart-sass/sass"
   },
   "os": [
-    "win32"
+    "android"
   ],
   "cpu": [
-    "arm64",
     "x64"
   ]
 }

--- a/npm/linux-musl-arm/README.md
+++ b/npm/linux-musl-arm/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-linux-musl-arm`
+
+This is the **linux-musl-arm** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-musl-arm/package.json
+++ b/npm/linux-musl-arm/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-embedded-win32-x64",
+  "name": "sass-embedded-linux-musl-arm",
   "version": "1.69.5",
-  "description": "The win32-x64 binary for sass-embedded",
+  "description": "The linux-musl-arm binary for sass-embedded",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
@@ -11,14 +11,10 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "bin": {
-    "sass": "./dart-sass/sass.bat"
-  },
   "os": [
-    "win32"
+    "linux"
   ],
   "cpu": [
-    "arm64",
-    "x64"
+    "arm"
   ]
 }

--- a/npm/linux-musl-arm64/README.md
+++ b/npm/linux-musl-arm64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-linux-musl-arm64`
+
+This is the **linux-musl-arm64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-musl-arm64/package.json
+++ b/npm/linux-musl-arm64/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-embedded-win32-x64",
+  "name": "sass-embedded-linux-musl-arm64",
   "version": "1.69.5",
-  "description": "The win32-x64 binary for sass-embedded",
+  "description": "The linux-musl-arm64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
@@ -11,14 +11,10 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "bin": {
-    "sass": "./dart-sass/sass.bat"
-  },
   "os": [
-    "win32"
+    "linux"
   ],
   "cpu": [
-    "arm64",
-    "x64"
+    "arm64"
   ]
 }

--- a/npm/linux-musl-ia32/README.md
+++ b/npm/linux-musl-ia32/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-linux-musl-ia32`
+
+This is the **linux-musl-ia32** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-musl-ia32/package.json
+++ b/npm/linux-musl-ia32/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-embedded-win32-x64",
+  "name": "sass-embedded-linux-musl-ia32",
   "version": "1.69.5",
-  "description": "The win32-x64 binary for sass-embedded",
+  "description": "The linux-musl-ia32 binary for sass-embedded",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
@@ -11,14 +11,10 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "bin": {
-    "sass": "./dart-sass/sass.bat"
-  },
   "os": [
-    "win32"
+    "linux"
   ],
   "cpu": [
-    "arm64",
-    "x64"
+    "ia32"
   ]
 }

--- a/npm/linux-musl-x64/README.md
+++ b/npm/linux-musl-x64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-linux-musl-x64`
+
+This is the **linux-musl-x64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/linux-musl-x64/package.json
+++ b/npm/linux-musl-x64/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-embedded-win32-x64",
+  "name": "sass-embedded-linux-musl-x64",
   "version": "1.69.5",
-  "description": "The win32-x64 binary for sass-embedded",
+  "description": "The linux-musl-x64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
@@ -11,14 +11,10 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "bin": {
-    "sass": "./dart-sass/sass.bat"
-  },
   "os": [
-    "win32"
+    "linux"
   ],
   "cpu": [
-    "arm64",
     "x64"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -35,12 +35,20 @@
     "test": "jest"
   },
   "optionalDependencies": {
+    "sass-embedded-android-arm": "1.69.5",
+    "sass-embedded-android-arm64": "1.69.5",
+    "sass-embedded-android-ia32": "1.69.5",
+    "sass-embedded-android-x64": "1.69.5",
     "sass-embedded-darwin-arm64": "1.69.5",
     "sass-embedded-darwin-x64": "1.69.5",
     "sass-embedded-linux-arm": "1.69.5",
     "sass-embedded-linux-arm64": "1.69.5",
     "sass-embedded-linux-ia32": "1.69.5",
     "sass-embedded-linux-x64": "1.69.5",
+    "sass-embedded-linux-musl-arm": "1.69.5",
+    "sass-embedded-linux-musl-arm64": "1.69.5",
+    "sass-embedded-linux-musl-ia32": "1.69.5",
+    "sass-embedded-linux-musl-x64": "1.69.5",
     "sass-embedded-win32-ia32": "1.69.5",
     "sass-embedded-win32-x64": "1.69.5"
   },


### PR DESCRIPTION
This PR adds support for musl-libc and android (and windows-arm64).

Because npm `optionalDependenices` only knows about generic linux, we have to install two variants on all linux system, and pick the correct one to run at runtime. It's not a huge problem other than waste some network bandwidth for download and a small amount of disk space.

Closes #263