### PR TITLE
Correct usage on win32-on-arm64 platforms to look for x64 native variant

### DIFF
--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -27,7 +27,7 @@ export const compilerCommand = (() => {
   // TODO: Make sure to remove "arm64" from "npm/win32-x64/package.json" when
   // this logic is removed once we have true windows-arm64 support.
   const arch =
-    platform === 'win32' && process.arch === 'arm64' ? 'x86' : process.arch;
+    platform === 'win32' && process.arch === 'arm64' ? 'x64' : process.arch;
 
   // find for development
   for (const path of ['vendor', '../../../lib/src/vendor']) {


### PR DESCRIPTION
#265 added support to install the x64 version when on arm64 Windows which is working fine, however there is a typo when determining the compiler path, so you get

`Embedded Dart Sass couldn't find the embedded compiler executable. Please make sure the optional dependency sass-embedded-win32-x86 is installed in node_modules`

Validated that things work fine with this change on arm64 Windows 11.