### PR TITLE
Serialize CSS string with SassString.prototype.toString()

### DIFF
--- a/lib/src/value/string.ts
+++ b/lib/src/value/string.ts
@@ -126,8 +126,9 @@ export class SassString extends Value {
   }
 
   toString(): string {
-    if (!this.hasQuotes)
+    if (!this.hasQuotes) {
       return this.text.replace(/\0/g, '\uFFFD').replace(/\n */g, ' ');
+    }
 
     // https://drafts.csswg.org/cssom/#serialize-a-string
     let buffer = '"';


### PR DESCRIPTION
This PR changes `SassString.prototype.toString()` to return a serialized CSS string similar to `dart-sass`.

Technically this is undocumented behavior, because it's not part of js-api spec. However, I have seen many users of ruby-sass, sassc-ruby, and dart-sass abusing this behavior, as demonstrated by the following example. Therefore, supporting this undocumented behavior would make adoption of `sass-embedded` more smooth.

``` js
import * as sass from 'sass-embedded';

const functions = {
  'image_path($source)': function (args) {
    const resolved = `/assets/${args[0].assertString('source').text}`;
    return new sass.SassString(resolved);
  },
  'image_url($source)': function (args) {
    const path = functions['image_path($source)'](args);
    return new sass.SassString(`url(${path.toString()})`, {quotes: false});
  },
};

console.log(
  // This is safe because it creates an AST node of `url()` Expression with SassString as argument. 
  sass.compileString('a { background: url(image_path("b.jpg")); }', {functions})
    .css
);

console.log(
  // This is not safe with the current `toString()` implementation, but users are tempted to do it
  // for convenience, as we don't have first class Expression support that would allow the host to
  // return a `url()` function expression.
  sass.compileString('a { background: image_url("b.jpg"); }', {functions}).css
);

const content = new sass.SassString('random #{$unsafe} content');
console.log(
  // In some cases this behavior is abused to the next level where string is directly embedded into
  // the sass input.
  // Note: `#` must to be escaped if sass interpolation is not desired.
  sass.compileString(
    `a { content: ${content.toString().replace(/#/g, '\\#')}; }`
  ).css
);
```