### PR TITLE
Use `process.argv[1]` as a fallback for `new NodePackageImporter()`

### DIFF
--- a/lib/src/importer-registry.ts
+++ b/lib/src/importer-registry.ts
@@ -2,6 +2,7 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import {createRequire} from 'module';
 import * as p from 'path';
 import {URL} from 'url';
 import {inspect} from 'util';
@@ -21,6 +22,10 @@ export class NodePackageImporter {
       ? p.resolve(entryPointDirectory)
       : require.main?.filename
       ? p.dirname(require.main.filename)
+      // TODO: Find a way to use `import.meta.main` once
+      // https://github.com/nodejs/node/issues/49440 is done.
+      : process.argv[1]
+      ? createRequire(process.argv[1]).resolve(process.argv[1])
       : undefined;
     if (!entryPointDirectory) {
       throw new Error(

--- a/lib/src/importer-registry.ts
+++ b/lib/src/importer-registry.ts
@@ -22,9 +22,9 @@ export class NodePackageImporter {
       ? p.resolve(entryPointDirectory)
       : require.main?.filename
       ? p.dirname(require.main.filename)
-      // TODO: Find a way to use `import.meta.main` once
+      : // TODO: Find a way to use `import.meta.main` once
       // https://github.com/nodejs/node/issues/49440 is done.
-      : process.argv[1]
+      process.argv[1]
       ? createRequire(process.argv[1]).resolve(process.argv[1])
       : undefined;
     if (!entryPointDirectory) {


### PR DESCRIPTION
Closes #274