### PR TITLE
Use native windows-arm64 dart-sass binary

### DIFF
--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -21,13 +21,7 @@ export const compilerCommand = (() => {
       ? 'linux-musl'
       : (process.platform as string);
 
-  // https://github.com/sass/embedded-host-node/issues/263
-  // Use windows-x64 emulation on windows-arm64
-  //
-  // TODO: Make sure to remove "arm64" from "npm/win32-x64/package.json" when
-  // this logic is removed once we have true windows-arm64 support.
-  const arch =
-    platform === 'win32' && process.arch === 'arm64' ? 'x64' : process.arch;
+  const arch = process.arch;
 
   // find for development
   for (const path of ['vendor', '../../../lib/src/vendor']) {

--- a/npm/win32-arm64/README.md
+++ b/npm/win32-arm64/README.md
@@ -1,0 +1,3 @@
+# `sass-embedded-win32-arm64`
+
+This is the **win32-arm64** binary for [`sass-embedded`](https://www.npmjs.com/package/sass-embedded)

--- a/npm/win32-arm64/package.json
+++ b/npm/win32-arm64/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-embedded-win32-x64",
+  "name": "sass-embedded-win32-arm64",
   "version": "1.72.0",
-  "description": "The win32-x64 binary for sass-embedded",
+  "description": "The win32-arm64 binary for sass-embedded",
   "repository": "sass/embedded-host-node",
   "author": "Google Inc.",
   "license": "MIT",
@@ -18,6 +18,6 @@
     "win32"
   ],
   "cpu": [
-    "x64"
+    "arm64"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "sass-embedded-linux-musl-arm64": "1.72.0",
     "sass-embedded-linux-musl-ia32": "1.72.0",
     "sass-embedded-linux-musl-x64": "1.72.0",
+    "sass-embedded-win32-arm64": "1.72.0",
     "sass-embedded-win32-ia32": "1.72.0",
     "sass-embedded-win32-x64": "1.72.0"
   },


### PR DESCRIPTION
https://github.com/sass/dart-sass/pull/2201

The dart-sass PR also adds linux-riscv64 builds, but nodejs does not have stable riscv64 support: https://github.com/nodejs/build/issues/2876 Therefore this PR only adds windows-arm64.