### PR TITLE
Fix test regression caused by node fixing CVE-2024-27980

### DIFF
--- a/lib/src/compiler/async.ts
+++ b/lib/src/compiler/async.ts
@@ -43,6 +43,10 @@ export class AsyncCompiler {
       // current working directory.
       // https://github.com/sass/embedded-host-node/pull/261#discussion_r1438712923
       cwd: path.dirname(compilerCommand[0]),
+      // Node blocks launching .bat and .cmd without a shell due to CVE-2024-27980
+      shell: ['.bat', '.cmd'].includes(
+        path.extname(compilerCommand[0]).toLowerCase()
+      ),
       windowsHide: true,
     }
   );

--- a/lib/src/compiler/sync.ts
+++ b/lib/src/compiler/sync.ts
@@ -43,6 +43,10 @@ export class Compiler {
       // current working directory.
       // https://github.com/sass/embedded-host-node/pull/261#discussion_r1438712923
       cwd: path.dirname(compilerCommand[0]),
+      // Node blocks launching .bat and .cmd without a shell due to CVE-2024-27980
+      shell: ['.bat', '.cmd'].includes(
+        path.extname(compilerCommand[0]).toLowerCase()
+      ),
       windowsHide: true,
     }
   );


### PR DESCRIPTION
This is mainly a test-only fix:

- `sass-embedded >=1.59.2` is not affected because in production release we always launch the `dart.exe` directly since this commit: https://github.com/sass/embedded-host-node/commit/308862033e00f7a28a83c3114941efb053c395f6
- `sass-embedded <1.59.2` would be broken if a windows user upgrades to the latest node with the fix for the CVE. There is no security risk for `sass-embedded` itself even if a windows user uses a vulnerable version of node, because we don't have any arguments when launching `.bat`, thus there is no risk of injection with in this project. However, there might be attack factors in other node dependencies, therefore, it is recommended for windows users to upgrade to latest node and `sass-embedded >=1.59.2`.
- Test is broken because we use the `.bat` wrapper in the test, this is now blocked with the CVE fix. This PR fixes this case by adding `shell: true`.