### PR TITLE
Set containingUrlUnused when FileImporter returns null

### DIFF
--- a/lib/src/importer-registry.ts
+++ b/lib/src/importer-registry.ts
@@ -209,7 +209,11 @@ export class ImporterRegistry<sync extends 'sync' | 'async'> {
         return thenOr(
           importer.findFileUrl(request.url, canonicalizeContext),
           url => {
-            if (!url) return new proto.InboundMessage_FileImportResponse();
+            if (!url) {
+              return new proto.InboundMessage_FileImportResponse({
+                containingUrlUnused: !canonicalizeContext.containingUrlAccessed,
+              });
+            }
             if (url.protocol !== 'file:') {
               throw (
                 `FileImporter ${inspect(importer)} returned non-file: URL ` +


### PR DESCRIPTION
https://github.com/sass/dart-sass/issues/2239

cc @nex3 This is why the test case I posted is only reproducible on embedded-host-node but not the transpiled JS version.