### PR TITLE
Fix release CI

### DIFF
--- a/tool/prepare-release.ts
+++ b/tool/prepare-release.ts
@@ -6,6 +6,7 @@ import {promises as fs} from 'fs';
 import * as shell from 'shelljs';
 
 import * as pkg from '../package.json';
+import {getDeprecations} from './get-deprecations';
 import {getLanguageRepo} from './get-language-repo';
 
 void (async () => {
@@ -13,6 +14,8 @@ void (async () => {
     await sanityCheckBeforeRelease();
 
     await getLanguageRepo('lib/src/vendor');
+
+    await getDeprecations('lib/src/vendor');
 
     console.log('Transpiling TS into dist.');
     shell.exec('tsc -p tsconfig.build.json');


### PR DESCRIPTION
@jathak This PR should fix the failed release. It was failing because `getDeprecations` was only called in `init.ts`, but release CI does not use `init.ts`.