### PR TITLE
Add a Sass executable wrapper that forwards to the correct exe

### DIFF
--- a/bin/sass
+++ b/bin/sass
@@ -1,0 +1,62 @@
+#!/bin/bash -e
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
+if [ "$(basename "$dir")" == bin ]; then
+    # Global executables are installed in .../bin/, and global libraries
+    # (including their dependencies) in .../lib/node_modules.
+    node_modules="$(dirname "$dir")/lib/node_modules"
+elif [ "$(basename "$dir")" == .bin ]; then
+    # Local dependency executables are installed in ./node_modules/.bin, and
+    # and their libraries in ./node_modules.
+    node_modules="$(dirname "$dir")"
+else
+    # If all else fails, try to find node_modules in a parent directory. We
+    # might execute this, for example, if someone runs the script from source.
+    while [ "$dir" != "/" ]; do
+        dir="$(dirname "$dir")"
+        if [ -d "$dir/node_modules" ]; then
+            node_modules="$dir/node_modules"
+            break
+        fi
+    done
+    echo "Could not find node_modules above ${BASH_SOURCE[0]}!" >&2
+    exit 1
+fi
+
+case "$(uname -s)" in
+    Linux*)
+        if [ ! -z "$ANDROID_ROOT" -a ! -z "$ANDROID_DATA" ]; then
+            os=android
+        else
+            os=linux
+        fi;;
+    Darwin*)
+        os=darwin;;
+    CYGWIN*|MINGW*|MSYS_NT*)
+        os=win32;;
+    *)
+        echo "Unknown operating system $(uname -s)!" >&2
+        exit 1
+esac
+
+musl=
+if [ "$os" == linux ] && grep -q /ld-musl- /bin/bash; then musl=-musl; fi
+
+case "$(uname -m)" in
+    aarch64*) arch=arm64;;
+    arm*) arch=arm;;
+    x86_64) arch=x64;;
+    i386|i486|i586|i686) arch=ia32;;
+    *)
+        echo "Unknown architecture $(uname -m)!" >&2
+        exit 1
+esac
+
+shared="$node_modules/sass-embedded-$os$musl-$arch"
+specific="$node_modules/sass-embedded/node_modules/sass-embedded-$os$musl-$arch"
+if [ -d "$specific" ]; then
+    exec "$specific/dart-sass/sass" "$@"
+else
+    exec "$shared/dart-sass/sass" "$@"
+fi
+

--- a/bin/sass
+++ b/bin/sass
@@ -1,62 +1,24 @@
-#!/bin/bash -e
+#!/usr/bin/env node
 
-dir="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
-if [ "$(basename "$dir")" == bin ]; then
-    # Global executables are installed in .../bin/, and global libraries
-    # (including their dependencies) in .../lib/node_modules.
-    node_modules="$(dirname "$dir")/lib/node_modules"
-elif [ "$(basename "$dir")" == .bin ]; then
-    # Local dependency executables are installed in ./node_modules/.bin, and
-    # and their libraries in ./node_modules.
-    node_modules="$(dirname "$dir")"
-else
-    # If all else fails, try to find node_modules in a parent directory. We
-    # might execute this, for example, if someone runs the script from source.
-    while [ "$dir" != "/" ]; do
-        dir="$(dirname "$dir")"
-        if [ -d "$dir/node_modules" ]; then
-            node_modules="$dir/node_modules"
-            break
-        fi
-    done
-    echo "Could not find node_modules above ${BASH_SOURCE[0]}!" >&2
-    exit 1
-fi
+const child_process = require("child_process");
+const {compilerCommand} = require("../dist/lib/src/compiler-path");
 
-case "$(uname -s)" in
-    Linux*)
-        if [ ! -z "$ANDROID_ROOT" -a ! -z "$ANDROID_DATA" ]; then
-            os=android
-        else
-            os=linux
-        fi;;
-    Darwin*)
-        os=darwin;;
-    CYGWIN*|MINGW*|MSYS_NT*)
-        os=win32;;
-    *)
-        echo "Unknown operating system $(uname -s)!" >&2
-        exit 1
-esac
+// TODO npm/cmd-shim#152 and yarnpkg/berry#6422 - If and when the package
+// managers support it, we should make this a proper shell script rather than a
+// JS wrapper.
 
-musl=
-if [ "$os" == linux ] && grep -q /ld-musl- /bin/bash; then musl=-musl; fi
+try {
+child_process.execFileSync(
+  compilerCommand[0], [...compilerCommand.slice(1), ...process.argv.slice(2)], {
+    stdio: 'inherit',
+    windowsHide: true
+});
+} catch (error) {
+  if (error.code) {
+    throw error;
+  } else {
+    process.exitCode = error.status;
+  }
+}
 
-case "$(uname -m)" in
-    aarch64*) arch=arm64;;
-    arm*) arch=arm;;
-    x86_64) arch=x64;;
-    i386|i486|i586|i686) arch=ia32;;
-    *)
-        echo "Unknown architecture $(uname -m)!" >&2
-        exit 1
-esac
-
-shared="$node_modules/sass-embedded-$os$musl-$arch"
-specific="$node_modules/sass-embedded/node_modules/sass-embedded-$os$musl-$arch"
-if [ -d "$specific" ]; then
-    exec "$specific/dart-sass/sass" "$@"
-else
-    exec "$shared/dart-sass/sass" "$@"
-fi
 

--- a/bin/sass.ts
+++ b/bin/sass.ts
@@ -1,18 +1,21 @@
 #!/usr/bin/env node
 
-const child_process = require("child_process");
-const {compilerCommand} = require("../dist/lib/src/compiler-path");
+import * as child_process from 'child_process';
+import {compilerCommand} from '../lib/src/compiler-path';
 
 // TODO npm/cmd-shim#152 and yarnpkg/berry#6422 - If and when the package
 // managers support it, we should make this a proper shell script rather than a
 // JS wrapper.
 
 try {
-child_process.execFileSync(
-  compilerCommand[0], [...compilerCommand.slice(1), ...process.argv.slice(2)], {
-    stdio: 'inherit',
-    windowsHide: true
-});
+  child_process.execFileSync(
+    compilerCommand[0],
+    [...compilerCommand.slice(1), ...process.argv.slice(2)],
+    {
+      stdio: 'inherit',
+      windowsHide: true,
+    }
+  );
 } catch (error) {
   if (error.code) {
     throw error;
@@ -20,5 +23,3 @@ child_process.execFileSync(
     process.exitCode = error.status;
   }
 }
-
-

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "bin": {"sass": "bin/sass"},
+  "bin": {"sass": "dist/bin/sass.js"},
   "scripts": {
     "init": "ts-node ./tool/init.ts",
     "check": "npm-run-all check:gts check:tsc",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "engines": {
     "node": ">=16.0.0"
   },
+  "bin": {"sass": "bin/sass"},
   "scripts": {
     "init": "ts-node ./tool/init.ts",
     "check": "npm-run-all check:gts check:tsc",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "exclude": [
+    "jest.config.js",
     "lib/src/vendor/dart-sass/**",
     "**/*.test.ts"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
   },
   "include": [
     "*.ts",
+    "bin/*.ts",
     "lib/**/*.ts",
     "tool/**/*.ts",
     "test/**/*.ts"


### PR DESCRIPTION
This allows users to run `npx sass` when they've just installed
`sass-embedded` and directly run the Dart VM.