### PR TITLE
Fix error with deprecation warnings and legacy importers

### DIFF
--- a/lib/src/legacy/utils.ts
+++ b/lib/src/legacy/utils.ts
@@ -8,7 +8,6 @@ import {pathToFileURL} from 'url';
 import {fileUrlToPathCrossPlatform} from '../utils';
 import {SourceSpan} from '../vendor/sass';
 import {legacyImporterFileProtocol} from './importer';
-import { remove } from 'immutable';
 
 /**
  * The URL protocol to use for URLs canonicalized using `LegacyImporterWrapper`.

--- a/lib/src/legacy/utils.ts
+++ b/lib/src/legacy/utils.ts
@@ -38,7 +38,13 @@ export function removeLegacyImporter(string: string): string {
 // syntax.
 export function removeLegacyImporterFromSpan(span: SourceSpan): SourceSpan {
   if (!span.url) return span;
-  return {...span, url: new URL(removeLegacyImporter(span.url.toString()))};
+  const url = removeLegacyImporter(span.url.toString());
+  return {
+    ...span,
+    url: URL.canParse(url)
+      ? new URL(url)
+      : new URL(url, `file://${process.cwd()}/`),
+  };
 }
 
 // Converts [path] to a `file:` URL and adds the [legacyImporterProtocolPrefix]

--- a/lib/src/legacy/utils.ts
+++ b/lib/src/legacy/utils.ts
@@ -8,6 +8,7 @@ import {pathToFileURL} from 'url';
 import {fileUrlToPathCrossPlatform} from '../utils';
 import {SourceSpan} from '../vendor/sass';
 import {legacyImporterFileProtocol} from './importer';
+import { remove } from 'immutable';
 
 /**
  * The URL protocol to use for URLs canonicalized using `LegacyImporterWrapper`.
@@ -39,12 +40,12 @@ export function removeLegacyImporter(string: string): string {
 export function removeLegacyImporterFromSpan(span: SourceSpan): SourceSpan {
   if (!span.url) return span;
   const url = removeLegacyImporter(span.url.toString());
-  return {
-    ...span,
-    url: URL.canParse(url)
-      ? new URL(url)
-      : new URL(url, `file://${process.cwd()}/`),
-  };
+  try {
+    return {...span, url: new URL(url)};
+  } catch (_) {
+    // Relative URL
+    return {...span, url: new URL(url, `file://${process.cwd()}`)};
+  }
 }
 
 // Converts [path] to a `file:` URL and adds the [legacyImporterProtocolPrefix]

--- a/lib/src/legacy/utils.ts
+++ b/lib/src/legacy/utils.ts
@@ -38,13 +38,13 @@ export function removeLegacyImporter(string: string): string {
 // syntax.
 export function removeLegacyImporterFromSpan(span: SourceSpan): SourceSpan {
   if (!span.url) return span;
-  const url = removeLegacyImporter(span.url.toString());
-  try {
-    return {...span, url: new URL(url)};
-  } catch (_) {
-    // Relative URL
-    return {...span, url: new URL(url, `file://${process.cwd()}`)};
-  }
+  return {
+    ...span,
+    url: new URL(
+      removeLegacyImporter(span.url.toString()),
+      pathToFileURL(process.cwd())
+    ),
+  };
 }
 
 // Converts [path] to a `file:` URL and adds the [legacyImporterProtocolPrefix]


### PR DESCRIPTION
See https://github.com/sass/sass/pull/3898.
See https://github.com/sass/sass-spec/pull/2004.
See https://github.com/sass/dart-sass/pull/2282.