### PR TITLE
Stricter checks in `LegacyColor` constructor

### DIFF
--- a/lib/src/legacy/value/color.ts
+++ b/lib/src/legacy/value/color.ts
@@ -2,12 +2,9 @@
 // MIT-style license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import {isNullOrUndefined} from '../../utils';
 import {SassColor} from '../../value/color';
 import {LegacyValueBase} from './base';
-
-function isUndefinedOrNull<A>(a: A): boolean {
-  return a === undefined || a === null;
-}
 
 export class LegacyColor extends LegacyValueBase<SassColor> {
   constructor(red: number, green: number, blue: number, alpha?: number);
@@ -26,7 +23,7 @@ export class LegacyColor extends LegacyValueBase<SassColor> {
     }
 
     let red: number;
-    if (isUndefinedOrNull(green) || isUndefinedOrNull(blue)) {
+    if (isNullOrUndefined(green) || isNullOrUndefined(blue)) {
       const argb = redOrArgb as number;
       alpha = (argb >> 24) / 0xff;
       red = (argb >> 16) % 0x100;

--- a/lib/src/legacy/value/color.ts
+++ b/lib/src/legacy/value/color.ts
@@ -5,6 +5,10 @@
 import {SassColor} from '../../value/color';
 import {LegacyValueBase} from './base';
 
+function isUndefinedOrNull<A>(a: A): boolean {
+  return a === undefined || a === null;
+}
+
 export class LegacyColor extends LegacyValueBase<SassColor> {
   constructor(red: number, green: number, blue: number, alpha?: number);
   constructor(argb: number);
@@ -22,7 +26,7 @@ export class LegacyColor extends LegacyValueBase<SassColor> {
     }
 
     let red: number;
-    if (green == undefined || blue == undefined) {
+    if (isUndefinedOrNull(green) || isUndefinedOrNull(blue)) {
       const argb = redOrArgb as number;
       alpha = (argb >> 24) / 0xff;
       red = (argb >> 16) % 0x100;

--- a/lib/src/legacy/value/color.ts
+++ b/lib/src/legacy/value/color.ts
@@ -22,7 +22,7 @@ export class LegacyColor extends LegacyValueBase<SassColor> {
     }
 
     let red: number;
-    if (!green || !blue) {
+    if (green == undefined || blue == undefined) {
       const argb = redOrArgb as number;
       alpha = (argb >> 24) / 0xff;
       red = (argb >> 16) % 0x100;


### PR DESCRIPTION
Fixes #348 

Rather than just checking if `green` or `blue` are falsy, the code now checks if they're `undefined` or `null`.