### PR TITLE
Update relative pathToFileURL to match node

### DIFF
--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -104,7 +104,7 @@ export function pathToUrlString(path: string): string {
   }
 
   if (process.platform === 'win32') {
-    fileUrl = fileUrl.replace(/%5C/g, '/').replace(/\\/g, '/');
+    fileUrl = fileUrl.replace(/%5C/g, '/');
   }
 
   return fileUrl;

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -86,18 +86,28 @@ export function valueError(message: string, name?: string): Error {
   return Error(name ? `$${name}: ${message}.` : `${message}.`);
 }
 
+// Node changed its implementation of pathToFileURL:
+// https://github.com/nodejs/node/pull/54545
+const unsafePathToFileURL = url.pathToFileURL('~').pathname.endsWith('~');
+
 /** Converts a (possibly relative) path on the local filesystem to a URL. */
 export function pathToUrlString(path: string): string {
   if (p.isAbsolute(path)) return url.pathToFileURL(path).toString();
 
   // percent encode relative path like `pathToFileURL`
-  return encodeURI(path)
-    .replace(/[#?]/g, encodeURIComponent)
-    .replace(
-      process.platform === 'win32' ? /%(5B|5C|5D|5E|7C)/g : /%(5B|5D|5E|7C)/g,
-      decodeURIComponent,
-    )
-    .replace(/\\/g, '/');
+  let fileUrl = encodeURI(path).replace(/[#?]/g, encodeURIComponent);
+
+  if (unsafePathToFileURL) {
+    fileUrl = fileUrl.replace(/%(5B|5D|5E|7C)/g, decodeURIComponent);
+  } else {
+    fileUrl = fileUrl.replace(/~/g, '%7E');
+  }
+
+  if (process.platform === 'win32') {
+    fileUrl = fileUrl.replace(/%5C/g, '/').replace(/\\/g, '/');
+  }
+
+  return fileUrl;
 }
 
 /**


### PR DESCRIPTION
Node recently changed what is escaped and what is not in pathToFileURL, causing tests to fail on node 22 LTS and higher:
https://github.com/nodejs/node/pull/54545