### PR TITLE
Remove unneeded `del` development dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@types/tar": "^6.1.0",
     "@types/varint": "^6.0.1",
     "@types/yargs": "^17.0.4",
-    "del": "^6.0.0",
     "extract-zip": "^2.0.1",
     "gts": "^6.0.2",
     "jest": "^29.4.1",

--- a/test/sandbox.ts
+++ b/test/sandbox.ts
@@ -4,7 +4,6 @@
 
 import * as fs from 'fs';
 import * as p from 'path';
-import * as del from 'del';
 
 import {PromiseOr} from '../lib/src/utils';
 
@@ -38,7 +37,7 @@ export async function run(
     await test((...paths) => p.join(testDir, ...paths));
   } finally {
     if (options?.sassPathDirs) process.env.SASS_PATH = undefined;
-    // TODO(awjin): Change this to rmSync once we drop support for Node 12.
-    del.sync(testDir, {force: true});
+
+    fs.rmSync(testDir, {force: true, recursive: true, maxRetries: 3});
   }
 }


### PR DESCRIPTION
Node.js 16 is the minimum supported version as per the package.json and this version contains the `rmSync` filesystem function which can replace the `del` package usage.