### PR TITLE
Remove unused `minipass` development dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "extract-zip": "^2.0.1",
     "gts": "^6.0.2",
     "jest": "^29.4.1",
-    "minipass": "7.1.2",
     "npm-run-all": "^4.1.5",
     "shelljs": "^0.8.4",
     "simple-git": "^3.15.1",


### PR DESCRIPTION
The `minipass` dependency does not appear to be used within the repository and has now been removed from the `package.json`.