### PR TITLE
Update description for sync-message-port in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ which are invoked by messages from the embedded compiler back to the host.
 Although this sort of two-way communication with an embedded process is
 inherently asynchronous in Node.js, this package supports the synchronous
 `compile()` API using a custom [synchronous message-passing library] that's
-implemented with the [`Atomics.wait()`] primitive. We hope to release this
-library as a stand-alone package at some point in the future.
+implemented with the [`Atomics.wait()`] primitive.
 
 [synchronous message-passing library]: https://github.com/sass/sync-message-port
 [`Atomics.wait()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait


### PR DESCRIPTION
I found that the description for sync-message-port is also outdated, aside from the link being outdate in #362. This PR remove the outdated sentence.