### PR TITLE
Fix potential Type Error

### DIFF
--- a/lib/src/legacy/importer.ts
+++ b/lib/src/legacy/importer.ts
@@ -168,7 +168,7 @@ export class LegacyImporterWrapper<sync extends 'sync' | 'async'>
 
     const prev = this.prev[this.prev.length - 1];
     return thenOr(
-      thenOr(this.invokeCallbacks(url, prev.url, options), result => {
+      thenOr(this.invokeCallbacks(url, prev?.url, options), result => {
         if (result instanceof Error) throw result;
         if (result === null) return null;
 


### PR DESCRIPTION
If the legacy compiler is used, and the file contains 2 `@use` or `@forward` (etc.) clauses, the compiler throws a Type Error, because `prev` is undefined and thus accessing `prev.url` is a Type Error, instead of handling the situation correctly. 