### PR TITLE
Fix passing variables across compilations

### DIFF
--- a/lib/src/function-registry.ts
+++ b/lib/src/function-registry.ts
@@ -18,6 +18,10 @@ import {Value} from './value';
  * execute them.
  */
 export class FunctionRegistry<sync extends 'sync' | 'async'> {
+  /**
+   * The globally unique identifier of the current compilation used for tracking
+   * the ownership of CompilerFunction and CompilerMixin objects.
+   */
   public readonly compileContext = Symbol();
   private readonly functionsByName = new Map<string, CustomFunction<sync>>();
   private readonly functionsById = new Map<number, CustomFunction<sync>>();

--- a/lib/src/function-registry.ts
+++ b/lib/src/function-registry.ts
@@ -18,6 +18,7 @@ import {Value} from './value';
  * execute them.
  */
 export class FunctionRegistry<sync extends 'sync' | 'async'> {
+  public readonly compileContext = Symbol();
   private readonly functionsByName = new Map<string, CustomFunction<sync>>();
   private readonly functionsById = new Map<number, CustomFunction<sync>>();
   private readonly idsByFunction = new Map<CustomFunction<sync>, number>();

--- a/lib/src/protofier.ts
+++ b/lib/src/protofier.ts
@@ -44,7 +44,7 @@ export class Protofier {
   get accessedArgumentLists(): number[] {
     return this.argumentLists
       .filter(list => list.keywordsAccessed)
-      .map(list => list.id as number);
+      .map(list => list.id!);
   }
 
   constructor(
@@ -86,9 +86,7 @@ export class Protofier {
       result.value = {case: 'list', value: list};
     } else if (value instanceof SassArgumentList) {
       if (value.compileContext === this.functions.compileContext) {
-        const list = create(proto.Value_ArgumentListSchema, {
-          id: value.id,
-        });
+        const list = create(proto.Value_ArgumentListSchema, {id: value.id});
         result.value = {case: 'argumentList', value: list};
       } else {
         const list = create(proto.Value_ArgumentListSchema, {

--- a/lib/src/value/argument-list.ts
+++ b/lib/src/value/argument-list.ts
@@ -13,7 +13,7 @@ export class SassArgumentList extends SassList {
    * compiler which argument lists have had their keywords accessed during a
    * function call.
    *
-   * The special ID 0 indicates an argument list constructed in the host.
+   * The special undefined indicates an argument list constructed in the host.
    *
    * This is marked as public so that the protofier can access it, but it's not
    * part of the package's public API and should not be accessed by user code.

--- a/lib/src/value/argument-list.ts
+++ b/lib/src/value/argument-list.ts
@@ -19,7 +19,18 @@ export class SassArgumentList extends SassList {
    * part of the package's public API and should not be accessed by user code.
    * It may be renamed or removed without warning in the future.
    */
-  readonly id: number;
+  readonly id: number | undefined;
+
+  /**
+   * If this argument list is constructed in the compiler, this is the unique
+   * context that the host uses to determine which compilation this argument
+   * list belongs to.
+   *
+   * This is marked as public so that the protofier can access it, but it's not
+   * part of the package's public API and should not be accessed by user code.
+   * It may be renamed or removed without warning in the future.
+   */
+  readonly compileContext: symbol | undefined;
 
   /**
    * The argument list's keywords. This isn't exposed directly so that we can
@@ -54,11 +65,13 @@ export class SassArgumentList extends SassList {
     keywords: Record<string, Value> | OrderedMap<string, Value>,
     separator?: ListSeparator,
     id?: number,
+    compileContext?: symbol,
   ) {
     super(contents, {separator});
     this.keywordsInternal = isOrderedMap(keywords)
       ? keywords
       : OrderedMap(keywords);
-    this.id = id ?? 0;
+    this.id = id;
+    this.compileContext = compileContext;
   }
 }

--- a/lib/src/value/mixin.ts
+++ b/lib/src/value/mixin.ts
@@ -18,13 +18,28 @@ export class SassMixin extends Value {
    */
   readonly id: number;
 
-  constructor(id: number) {
+  /**
+   * This is the unique context that the host uses to determine which
+   * compilation this mixin belongs to.
+   *
+   * This is marked as public so that the protofier can access it, but it's not
+   * part of the package's public API and should not be accessed by user code.
+   * It may be renamed or removed without warning in the future.
+   */
+  readonly compileContext: symbol;
+
+  constructor(id: number, compileContext: symbol) {
     super();
     this.id = id;
+    this.compileContext = compileContext;
   }
 
   equals(other: Value): boolean {
-    return other instanceof SassMixin && other.id === this.id;
+    return (
+      other instanceof SassMixin &&
+      other.compileContext === this.compileContext &&
+      other.id === this.id
+    );
   }
 
   hashCode(): number {


### PR DESCRIPTION
This PR addresses https://github.com/sass/dart-sass/issues/2542 for the embedded host side by porting https://github.com/sass-contrib/sass-embedded-host-ruby/compare/c05a8f54a1eaddd70cd7d6278cf111c938a4e93f...0378284e42b304409ef48ce7ef9c9e4dae48a77c.

https://github.com/sass/dart-sass/pull/2544
https://github.com/sass/sass-spec/pull/2053