### PR TITLE
Bump protocol-version to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sass-embedded",
   "version": "1.87.0",
-  "protocol-version": "3.1.0",
+  "protocol-version": "3.2.0",
   "compiler-version": "1.87.0",
   "description": "Node.js library that communicates with Embedded Dart Sass using the Embedded Sass protocol",
   "repository": "sass/embedded-host-node",


### PR DESCRIPTION
The protocol version was updated in https://github.com/sass/sass/pull/4073. The change was submitted, but this repo hasn't been updated. This repo requires matching the exact same value in https://github.com/sass/sass