### PR TITLE
Add libc field to package.json

### DIFF
--- a/npm/linux-arm/package.json
+++ b/npm/linux-arm/package.json
@@ -14,6 +14,7 @@
   "os": [
     "linux"
   ],
+  "libc": "glibc",
   "cpu": [
     "arm"
   ]

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -14,6 +14,7 @@
   "os": [
     "linux"
   ],
+  "libc": "glibc",
   "cpu": [
     "arm64"
   ]

--- a/npm/linux-musl-arm/package.json
+++ b/npm/linux-musl-arm/package.json
@@ -14,6 +14,7 @@
   "os": [
     "linux"
   ],
+  "libc": "musl",
   "cpu": [
     "arm"
   ]

--- a/npm/linux-musl-arm64/package.json
+++ b/npm/linux-musl-arm64/package.json
@@ -14,6 +14,7 @@
   "os": [
     "linux"
   ],
+  "libc": "musl",
   "cpu": [
     "arm64"
   ]

--- a/npm/linux-musl-riscv64/package.json
+++ b/npm/linux-musl-riscv64/package.json
@@ -14,6 +14,7 @@
   "os": [
     "linux"
   ],
+  "libc": "musl",
   "cpu": [
     "riscv64"
   ]

--- a/npm/linux-musl-x64/package.json
+++ b/npm/linux-musl-x64/package.json
@@ -14,6 +14,7 @@
   "os": [
     "linux"
   ],
+  "libc": "musl",
   "cpu": [
     "x64"
   ]

--- a/npm/linux-riscv64/package.json
+++ b/npm/linux-riscv64/package.json
@@ -14,6 +14,7 @@
   "os": [
     "linux"
   ],
+  "libc": "glibc",
   "cpu": [
     "riscv64"
   ]

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -14,6 +14,7 @@
   "os": [
     "linux"
   ],
+  "libc": "glibc",
   "cpu": [
     "x64"
   ]


### PR DESCRIPTION
This is a new feature in `npm >=10`: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#libc

It allows us to install the dart linux binary for only the current `libc` (glibc or musl). On older `npm <10`, this key is simply ignored and both glibc and musl binaries will be installed like before.

The possible values for `libc` key is undocumented, but it appears to be defined and used at https://github.com/npm/npm-install-checks/blob/main/lib/current-env.js