### PR TITLE
Fix `ts-node` with `--no-experimental-strip-types`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,19 @@ jobs:
       - name: Compile
         run: npm run compile
 
+      # The new --experimental-strip-types option conflicts with `ts-node`. Disable it if it's supported.
+      # See: https://github.com/TypeStrong/ts-node/issues/2152
+      # TODO: switch to native typescript support once node<22 are dropped
+      - name: Check NODE_OPTIONS
+        id: node-options
+        run: |
+          echo "NODE_OPTIONS=$(node --no-experimental-strip-types -e 'console.log("--no-experimental-strip-types")')" | tee -a "$GITHUB_OUTPUT"
+
       - name: Run tests
         run: npm run js-api-spec -- --sassPackage .. --sassSassRepo ../language
         working-directory: sass-spec
+        env:
+          NODE_OPTIONS: ${{ steps.node-options.outputs.NODE_OPTIONS }}
 
   deploy_npm:
     name: Deploy npm

--- a/lib/src/compiler-path.ts
+++ b/lib/src/compiler-path.ts
@@ -37,7 +37,7 @@ export const compilerCommand = (() => {
   try {
     return [
       process.execPath,
-      p.join(p.dirname(require.resolve('sass')), 'sass.js'),
+      p.join(p.dirname(require.resolve('sass')), 'sass.js'), // eslint-disable-line n/no-extraneous-require
     ];
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND') {


### PR DESCRIPTION
`ts-node` is broken out of box on node >=22.18.0 due to `--experimental-strip-types` being enabled by default.

As we still need to test older node version without native typescript support, this PR sets `NODE_OPTIONS=--no-experimental-strip-types` if necessary.