### PR TITLE
Exclude obsolete deprecations when making a version fatal

### DIFF
--- a/lib/src/deprecations.ts
+++ b/lib/src/deprecations.ts
@@ -130,6 +130,7 @@ function isFatal(
   for (const fatal of options.fatalDeprecations ?? []) {
     if (fatal instanceof Version) {
       if (versionNumber === null) continue;
+      if (deprecation.obsoleteIn !== null) continue;
       if (
         versionNumber <=
         fatal.major * 1000000 + fatal.minor * 1000 + fatal.patch


### PR DESCRIPTION
This was fixed for the CLI, Dart API, and compiled to JS API in sass/dart-sass#2671, but the embedded host implements this logic separately.